### PR TITLE
Add line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.java text eol=lf
+*.md text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
## Summary
- add .gitattributes for consistent text normalization
- pin LF endings for Java, Markdown, XML and YAML files

## Tests
- Not run (repository metadata only).