### PR TITLE
Exclude workflows from Sonar CPD checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
 # Kata and algorithm exercise solutions naturally repeat short structural patterns.
 # Keep SonarCloud issue/security analysis, but exclude these training folders from CPD.
-sonar.cpd.exclusions=src/main/java/kyu*/**/*,src/main/java/algorithms/**/*,src/test/java/**/*
+sonar.cpd.exclusions=src/main/java/kyu*/**/*,src/main/java/algorithms/**/*,src/test/java/**/*,.github/**/*


### PR DESCRIPTION
## Summary
- exclude workflow YAML from Sonar duplication checks
- keep Sonar issue/security analysis enabled for repository code