### PR TITLE
Add failure message style notes

### DIFF
--- a/docs/kata-practice/failure-message-style.md
+++ b/docs/kata-practice/failure-message-style.md
@@ -1,0 +1,15 @@
+# Failure Message Style Notes
+
+Readable failures shorten the loop when a kata implementation changes.
+
+## Review prompts
+
+- Name the scenario in the test method or display name.
+- Keep expected values close to the assertion.
+- Add custom messages only when the assertion would be ambiguous.
+- Prefer small fixtures over comments explaining a large fixture.
+- Use parameter names that describe the behavior under test.
+
+## Local check
+
+Run the focused test once after renaming scenarios.


### PR DESCRIPTION
## Summary
- Adds notes for readable kata test failures.

## Validation
- Documentation-only change.
