### PR TITLE
docs: present Java algorithms reliability showcase

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: New kata, test strategy, or repository quality improvement
+about: New reference implementation, test strategy, or repository quality improvement
 title: "[feat] "
 labels: ["enhancement"]
 assignees: ["krotname"]

--- a/.github/workflows/no-releases.yml
+++ b/.github/workflows/no-releases.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - name: Explain release policy
         run: |
-          echo "::error title=No releases::CodewarsKataJava is a kata practice repository and does not publish GitHub releases or release tags. Use the regular CI workflow for validation."
+          echo "::error title=No releases::JavaAlgorithmsShowcase publishes reference implementations without GitHub releases or release tags. Use the regular CI workflow for validation."
           echo "This workflow exists only to make accidental release or release-tag events visible."
           exit 1

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,3 @@
 # SonarQube Cloud automatic analysis ignores sonar-project.properties.
-# These kata/algorithm files intentionally repeat contest-style I/O and setup patterns.
+# These source-derived algorithm files intentionally repeat contest-style I/O and setup patterns.
 sonar.cpd.exclusions=src/main/java/algorithms/sprint1/SleightOfHand.java,src/main/java/algorithms/sprint8/PackedPrefix.java,src/main/java/algorithms/sprint2/Deque.java,src/main/java/algorithms/sprint6/DorogayaSet.java,src/main/java/algorithms/sprint8/Crib.java,src/main/java/algorithms/sprint6/WaterWorld.java,src/main/java/algorithms/sprint2/Calculator.java,src/main/java/algorithms/sprint7/EqualSums.java,src/main/java/algorithms/sprint1/Distances.java,src/main/java/algorithms/sprint7/LevenshteinDistance.java,src/main/java/algorithms/sprint5/PyramidSort.java,src/main/java/algorithms/sprint4/FindSystem.java,src/main/java/algorithms/sprint3/FastSort.java

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Repository model
 
-- `src/main/java` contains production kata implementations grouped by family (`kyu3`, `kyu4`, `kyu5`, `kyu6`, `kyu7`, `leetcode`, `interview`, `coderun`, `other`, `transactions`).
+- `src/main/java` contains reference implementations grouped by engineering concern (`algorithms`, `transactions`, `common`) and by retained source provenance (`kyu3`, `kyu4`, `kyu5`, `kyu6`, `kyu7`, `leetcode`, `interview`, `coderun`, `other`).
 - `src/test/java` mirrors the same package layout.
 - `src/test/java/quality` contains suite-level entry points for local and CI review:
   - `SmokeSuite` – fast baseline visibility of all unit tests.
@@ -14,7 +14,7 @@
 ## Design principles used in this repo
 
 - Deterministic API behavior where possible.
-- No mutable side effects in pure kata methods.
+- No mutable side effects in pure algorithm methods.
 - Input validation and boundary handling through explicit conditions.
 - Shared conventions and reviewability:
   - test classes are colocated with implementation packages;
@@ -29,7 +29,7 @@
 - **Security**: CodeQL workflow and Security policy in the repo root.
 - **Intentional static-analysis exceptions:** `config/checkstyle/suppressions.xml`
   documents generated smoke wrappers, while `config/spotbugs-exclude.xml` keeps
-  Codewars-compatible public API names documented instead of hiding them in code.
+  source-compatible public API names documented instead of hiding them in code.
 
 ## Future quality directions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Corrected boundary, overflow, validation, determinism and complexity defects across kata utilities.
+- Corrected boundary, overflow, validation, determinism and complexity defects across algorithm utilities.
 - Hardened transaction validation and made returned status collections immutable.
 - Replaced unbounded iteration in encryption and range-counting helpers with logarithmic algorithms.
 - Made the generated smoke harness fail when every executable API path fails.
@@ -14,7 +14,7 @@
 ## 1.1 - public quality hardening (2026-06-09)
 
 - Added CI, static analysis, and dependency management updates for repository quality.
-- Standardized test strategy and introduced a shared smoke harness for kata classes.
+- Standardized test strategy and introduced a shared smoke harness for reference implementations.
 - Added dedicated integration tests for the transactions validation flow.
 - Expanded README with bilingual project guidance.
 - Added community/maintenance docs (`CONTRIBUTING`, `SECURITY`, `CODE_OF_CONDUCT`).
@@ -27,5 +27,5 @@
 - Added repository-level line-ending normalization with `.gitattributes`.
 - Expanded the meaningful test baseline to 455 tests across unit/smoke, integration and property categories.
 - Set enforced JaCoCo coverage gates to 70% line, branch and instruction coverage.
-- Reduced SpotBugs debt to zero reported findings with explicit compatibility exclusions for Codewars API names.
+- Reduced SpotBugs debt to zero reported findings with explicit exclusions for source-compatible API names.
 - Reduced PMD debt to zero reported findings by removing unused code/imports and simplifying safe expressions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,4 @@ Thank you for interest in this repository.
 - `mvn -B verify` runs the full quality stack: tests, coverage, checkstyle, PMD and SpotBugs.
 - CI enforces reproducible builds on Java 17 and 21.
 - Prefer explicit comments for non-obvious logic in complex methods.
-- If you touch static API in a kata class, keep test names meaningful and deterministic.
+- If you touch a source-compatible static API, keep test names meaningful and deterministic.

--- a/README.en.md
+++ b/README.en.md
@@ -1,83 +1,71 @@
-# Codewars Solutions
+# Java Algorithms & Reliability Showcase
 
-[Russian](README.md)
+[Русская версия](README.md)
 
+Curated Java reference implementations for deterministic algorithms and stateful validation. The project demonstrates API design, edge-case handling, property-based testing, static analysis, and reproducible CI.
 
-This repository is a portfolio-grade Java kata workspace focused on deterministic algorithms, reproducible tests, visible quality workflows, readable production code, and bilingual project documentation.
+[![CI](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/maven.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/maven.yml)
+[![Quality Gates](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/quality.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/quality.yml)
+[![CodeQL](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/codeql-analysis.yml)
+[![Coverage](https://codecov.io/gh/krotname/JavaAlgorithmsShowcase/branch/main/graph/badge.svg)](https://app.codecov.io/gh/krotname/JavaAlgorithmsShowcase)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/krotname/JavaAlgorithmsShowcase/badge)](https://securityscorecards.dev/viewer/?uri=github.com/krotname/JavaAlgorithmsShowcase)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13151/badge)](https://www.bestpractices.dev/projects/13151)
+[![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-0f8a16)](LICENSE)
+[![Java](https://img.shields.io/badge/Java-17%2B-007396.svg)](https://adoptium.net/)
+[![JUnit](https://img.shields.io/badge/JUnit-6-25A162.svg)](https://junit.org/)
+[![Maven](https://img.shields.io/badge/Maven-3.9%2B-C71A36.svg)](https://maven.apache.org/)
 
-## Why This Repository Exists
+![Java Algorithms & Reliability Showcase](docs/assets/project-icon.svg)
 
-- It demonstrates practical coding and test engineering from problem solving to delivery quality.
-- Solutions are organized by difficulty/source: kyu, LeetCode, interview, transactions, and other groups.
-- Static checks and tests are visible and runnable in one place.
+## Selected engineering components
 
-## Repository Map
+| Component | Engineering problem | What it demonstrates |
+| --- | --- | --- |
+| [Transaction validation](src/main/java/transactions) | Ordered, stateful operations; cascading invalidation; balance and overflow boundaries | Deterministic state transitions, immutable results, integration scenarios |
+| [Algorithm utilities](src/main/java/algorithms) | Boundary conditions, complexity, stream and file I/O | Deterministic APIs, explicit complexity tradeoffs, edge cases, and property-based invariants |
+| [Parsing / validation](src/main/java/common/SafeParse.java) | Malformed numeric and text input | Explicit contracts, preserved exception causality, unit tests, and static analysis |
 
-- `src/main/java` - production solutions and domain classes.
-- `src/test/java` - tests and quality suites:
-  - `quality.SmokeSuite` for unit/smoke tests.
-  - `quality.IntegrationSuite` for transaction scenario tests.
-  - `quality.PropertySuite` for curated property-based tests.
-- `.github` - CI workflows, Dependabot, and repository templates.
-- `ARCHITECTURE.md` - architectural and reviewability notes.
-- `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `TESTING.md` - project governance.
+This is an engineering demonstration repository, not a commercial product. Implementations are selected to make code quality, test strategy, and the development process directly reviewable.
 
-## Testing Strategy
+## Verification strategy
 
-- Smoke/unit tests cover each kata directly and are grouped by `quality.SmokeSuite`.
-- Integration tests cover transaction validation state and ordering through `quality.IntegrationSuite`.
-- Property-based tests are grouped in `quality.PropertySuite`.
-- UI tests are not applicable because this repository has no UI layer.
-- Static quality gates include Checkstyle, PMD, and SpotBugs in Maven verify.
-- JaCoCo fails `mvn verify` below 70% line, branch, or instruction coverage.
+- **Smoke / unit:** baseline contracts for public APIs.
+- **Integration:** transaction state and ordering, plus algorithm CLI contracts.
+- **Property-based (jqwik):** invariants over broad generated input sets.
+- **Static analysis:** Checkstyle, PMD, and SpotBugs with a zero-new-violation baseline.
+- **Coverage:** JaCoCo fails `mvn verify` below 70% line, branch, or instruction coverage.
+- **Security:** CodeQL, dependency review, and OpenSSF Scorecard.
+- **Reproducibility:** Java 17/21 CI and a strict offline Windows gate after Maven cache priming.
 
-## CI and Quality Signals
-
-- `.github/workflows/maven.yml` runs category jobs on JDK 21 and full `mvn verify` on JDK 17 and 21.
-- The same workflow validates the strict offline PowerShell gate on Windows after an explicit dependency-prime step.
-- `.github/workflows/quality.yml` runs Checkstyle, PMD, and SpotBugs without executing tests.
-- `.github/workflows/codeql-analysis.yml` runs security analysis.
-- `.github/dependabot.yml` keeps dependency automation visible.
-
-## Default Branch Governance
-
-`main` intentionally uses lightweight branch governance. This is a personal educational kata journal where small solution, test, and explanation updates are often pushed directly to keep a fast practice loop. Public quality assurance comes from CI, CodeQL, quality gates, Dependabot, the Security Policy, and reproducible local commands. Substantive changes that affect kata behavior or quality policy still use the normal PR/review workflow.
-
-The absence of branch protection on `main` is an intentional project-specific exception and should not be treated as a hardening defect.
-
-## Local Run
+## Local verification
 
 ```bash
 mvn -B verify
-mvn -B test
 mvn -B test -Dgroups='smoke'
 mvn -B test -Dgroups='integration'
 mvn -B test -Dgroups='property'
 mvn -B -DskipTests checkstyle:check pmd:check spotbugs:check
-mvn -B test -Dtest='quality.SmokeSuite'
-mvn -B test -Dtest='quality.IntegrationSuite'
-mvn -B test -Dtest='quality.PropertySuite'
 ```
 
-Run the complete PowerShell gate without network access:
+Run the complete offline gate in PowerShell:
 
 ```powershell
 .\scripts\run-offline-gate.ps1
 ```
 
-See [`TESTING.md`](TESTING.md) for strict dependency-cache mode and the documented
-cached-JUnit fallback.
+See [TESTING.md](TESTING.md) for the complete test matrix and dependency-cache rules.
 
-## Reviewer Checklist
+## Repository map
 
-- No hidden mutation of test inputs inside algorithmic methods.
-- Meaningful method-level comments in non-obvious logic.
-- Deterministic edge-case handling in boundary tests.
-- Governance artifacts for maintainability and process.
+- `src/main/java/transactions` — stateful validation and its transaction domain model.
+- `src/main/java/algorithms` — sorting, graphs, dynamic programming, data structures, and CLI algorithms.
+- `src/main/java/common`, `interview`, `leetcode`, `coderun`, `other`, `kyu*` — utilities and implementations with provenance-preserving layout.
+- `src/test/java/quality` — entry points for smoke, integration, and property suites.
+- `.github/workflows` — CI, quality gates, CodeQL, dependency review, and supply-chain checks.
+- [ARCHITECTURE.md](ARCHITECTURE.md), [TESTING.md](TESTING.md), and [SECURITY.md](SECURITY.md) — architecture, test strategy, and security policy.
 
-## Local Quality Policy
+## Sources & provenance
 
-- Use ASCII-only patch style unless a file already contains another script.
-- Keep public method behavior deterministic.
-- Add or adjust tests for changed branch behavior.
-- Keep comments close to complex algorithmic logic.
+Problems and APIs come from several sources: Codewars, LeetCode, Yandex algorithm tracks, CodeRun, interview tasks, and standalone exercises. Links to original statements and compatible signatures remain in the code where they help verification.
+
+The `kyu*` packages are retained as internal provenance and compatibility structure. They are not the project's primary taxonomy; the showcase is organized around engineering problems, contracts, and test strategy.

--- a/README.md
+++ b/README.md
@@ -1,92 +1,71 @@
-# Решения с Codewars
+# Java Algorithms & Reliability Showcase
 
-[English](README.en.md)
+[English version](README.en.md)
 
-[![CI](https://github.com/krotname/CodewarsKataJava/actions/workflows/maven.yml/badge.svg)](https://github.com/krotname/CodewarsKataJava/actions/workflows/maven.yml)
-[![Quality Gates](https://github.com/krotname/CodewarsKataJava/actions/workflows/quality.yml/badge.svg)](https://github.com/krotname/CodewarsKataJava/actions/workflows/quality.yml)
-[![CodeQL](https://github.com/krotname/CodewarsKataJava/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/krotname/CodewarsKataJava/actions/workflows/codeql-analysis.yml)
-[![Coverage](https://codecov.io/gh/krotname/CodewarsKataJava/branch/main/graph/badge.svg)](https://app.codecov.io/gh/krotname/CodewarsKataJava)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/krotname/CodewarsKataJava/badge)](https://securityscorecards.dev/viewer/?uri=github.com/krotname/CodewarsKataJava)
+Curated Java reference implementations for deterministic algorithms and stateful validation. The project demonstrates API design, edge-case handling, property-based testing, static analysis, and reproducible CI.
+
+[![CI](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/maven.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/maven.yml)
+[![Quality Gates](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/quality.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/quality.yml)
+[![CodeQL](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/krotname/JavaAlgorithmsShowcase/actions/workflows/codeql-analysis.yml)
+[![Coverage](https://codecov.io/gh/krotname/JavaAlgorithmsShowcase/branch/main/graph/badge.svg)](https://app.codecov.io/gh/krotname/JavaAlgorithmsShowcase)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/krotname/JavaAlgorithmsShowcase/badge)](https://securityscorecards.dev/viewer/?uri=github.com/krotname/JavaAlgorithmsShowcase)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13151/badge)](https://www.bestpractices.dev/projects/13151)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-0f8a16)](LICENSE)
 [![Java](https://img.shields.io/badge/Java-17%2B-007396.svg)](https://adoptium.net/)
 [![JUnit](https://img.shields.io/badge/JUnit-6-25A162.svg)](https://junit.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9%2B-C71A36.svg)](https://maven.apache.org/)
 
-![Codewars Kata Java](docs/assets/project-icon.svg)
+![Java Algorithms & Reliability Showcase](docs/assets/project-icon.svg)
 
-[English README](README.en.md)
+## Отобранные инженерные компоненты
 
-## Русский
+| Компонент | Инженерная задача | Что демонстрирует |
+| --- | --- | --- |
+| [Transaction validation](src/main/java/transactions) | Порядок и состояние операций, каскадная невалидность, баланс и переполнение | Детерминированные переходы состояния, неизменяемый результат, интеграционные сценарии |
+| [Algorithm utilities](src/main/java/algorithms) | Граничные условия, сложность, поточный и файловый ввод-вывод | Детерминированные API, явные компромиссы по сложности, edge cases и property-based инварианты |
+| [Parsing / validation](src/main/java/common/SafeParse.java) | Некорректный числовой и текстовый ввод | Явные контракты, сохранение причины исключения, unit-тесты и статический анализ |
 
-### Зачем нужен этот репозиторий
+Это демонстрационный инженерный репозиторий, а не коммерческий продукт. Реализации отобраны так, чтобы на ревью были видны качество кода, тестовая стратегия и воспроизводимый процесс разработки.
 
-- Показать не только решения задач, но и зрелый рабочий процесс: тестирование, CI, проверки качества, документацию.
-- Сохранить код понятным для ревью: читаемые структуры, воспроизводимые команды и прозрачные критерии качества.
-- Поддерживать русско- и англоязычную документацию.
+## Что проверяется
 
-### Карта репозитория
+- **Smoke / unit:** базовые контракты публичных API.
+- **Integration:** состояние и порядок транзакций, а также CLI-контракты алгоритмов.
+- **Property-based (jqwik):** инварианты на широких наборах сгенерированных входов.
+- **Static analysis:** Checkstyle, PMD и SpotBugs с нулевым допустимым числом новых нарушений.
+- **Coverage:** JaCoCo останавливает `mvn verify`, если покрытие строк, ветвлений или инструкций ниже 70%.
+- **Security:** CodeQL, dependency review и OpenSSF Scorecard.
+- **Reproducibility:** Java 17/21 в CI и строгий офлайн-гейт на Windows после заполнения Maven-кэша.
 
-- `src/main/java` — решения/бизнес-логика
-- `src/test/java` — тесты и саппортивные suites
-  - `quality.SmokeSuite` (unit/smoke)
-  - `quality.IntegrationSuite` (интеграционные проверки транзакций)
-  - `quality.PropertySuite` (property-тесты на jqwik, сгруппировано)
-- `.github` — CI, dependabot, шаблоны
-- `ARCHITECTURE.md` — архитектурные заметки для ревью.
-- `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `TESTING.md`
-
-### Стратегия тестов
-
-- **Smoke / Unit**: базовая проверка API каждого решения.
-- **Интеграционные**: последовательности и состояние в `transactions`.
-- **Property-based (jqwik)**: инварианты в подходящих задачах.
-- **UI**: не применимо (`N/A`), в репозитории нет UI-слоя.
-- **Статический контроль**: Checkstyle, PMD, SpotBugs в `verify`; сборка падает при нарушениях.
-- **Coverage-gate**: JaCoCo ломает `mvn verify`, если покрытие ниже 70% строк, ветвлений
-  или инструкций.
-- **Отдельный quality-гейт**: workflow `.github/workflows/quality.yml` для чистых статических проверок без прогона тестов.
-- **Офлайн-гейт**: Windows CI после явного заполнения кэша запускает PowerShell-проверку в строгом режиме без сети.
-- **Checkstyle / PMD / SpotBugs**: статические проверки заведены в quality-гейт.
-- **Checkstyle**: проектный набор правил в `config/checkstyle/checkstyle.xml` и явные suppressions для generated smoke-тестов.
-- **SpotBugs**: чистый отчёт с явными исключениями совместимости в `config/spotbugs-exclude.xml`.
-### Как запускать
+## Локальная проверка
 
 ```bash
 mvn -B verify
-mvn -B test
 mvn -B test -Dgroups='smoke'
 mvn -B test -Dgroups='integration'
 mvn -B test -Dgroups='property'
 mvn -B -DskipTests checkstyle:check pmd:check spotbugs:check
-mvn -B test -Dtest='quality.SmokeSuite'
-mvn -B test -Dtest='quality.IntegrationSuite'
-mvn -B test -Dtest='quality.PropertySuite'
 ```
 
-Полный локальный прогон без сети на PowerShell:
+Полный офлайн-прогон на PowerShell:
 
 ```powershell
 .\scripts\run-offline-gate.ps1
 ```
 
-Подробности о строгом режиме зависимостей и fallback на уже закэшированную версию JUnit
-описаны в [`TESTING.md`](TESTING.md).
+Подробная тестовая матрица и правила кэша описаны в [TESTING.md](TESTING.md).
 
-### Что отражает репозиторий как "публично привлекательный"
+## Карта репозитория
 
-- Есть CI с понятными этапами и артефактами (`surefire`, `jacoco`).
-- Есть требования и процесс (`CONTRIBUTING`, `SECURITY`, `CODE_OF_CONDUCT`).
-- Есть явная стратегия тестирования и локальные команды.
-- Есть заметки о покрытии и безопасности.
-- Есть архитектурная карта для быстрой оценки качества решений (`ARCHITECTURE.md`).
+- `src/main/java/transactions` — stateful validation и доменная модель транзакций.
+- `src/main/java/algorithms` — сортировка, графы, динамическое программирование, структуры данных и CLI-алгоритмы.
+- `src/main/java/common`, `interview`, `leetcode`, `coderun`, `other`, `kyu*` — утилиты и реализации с сохранённой provenance-структурой.
+- `src/test/java/quality` — точки входа для smoke-, integration- и property-наборов.
+- `.github/workflows` — CI, quality gates, CodeQL, dependency review и supply-chain проверки.
+- [ARCHITECTURE.md](ARCHITECTURE.md), [TESTING.md](TESTING.md), [SECURITY.md](SECURITY.md) — архитектура, тестовая стратегия и security policy.
 
-### Особенность управления default branch
+## Sources & provenance
 
-`main` намеренно остается с облегченным branch governance. Это персональный учебный kata-журнал, где небольшие правки решений, тестов и пояснений часто вносятся напрямую, чтобы сохранять быстрый цикл тренировки. Публичные гарантии качества обеспечиваются CI, CodeQL, quality gates, Dependabot, Security Policy и воспроизводимыми локальными командами. Для содержательных изменений, влияющих на поведение задач или процесс качества, по-прежнему используется обычный PR/review-подход.
-Отсутствие branch protection для `main` является осознанным исключением этого проекта и не должно трактоваться как дефект hardening-модели.
+Задачи и API происходят из нескольких источников: Codewars, LeetCode, алгоритмические треки Яндекса, CodeRun, интервью и самостоятельные задачи. Ссылки на исходные условия и совместимые сигнатуры сохранены в коде там, где это важно для проверяемости.
 
-### Default branch governance note
-
-`main` intentionally uses lightweight branch governance. This is a personal educational kata journal where small solution, test, and explanation updates are often pushed directly to preserve a fast practice loop. Public quality assurance comes from CI, CodeQL, quality gates, Dependabot, the Security Policy, and reproducible local commands. Substantive changes that affect kata behavior or quality policy still use the normal PR/review workflow.
-The absence of branch protection on `main` is an intentional project-specific exception and should not be treated as a hardening defect.
+Пакеты `kyu*` оставлены как внутренняя структура происхождения и совместимости. Они не являются основной таксономией проекта: витрина организована вокруг инженерных задач, контрактов и тестовой стратегии.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,14 @@
 
 ## Supported versions
 
-Security fixes are handled on the default branch. This repository contains educational kata solutions, so release branches are not maintained separately.
+Security fixes are handled on the default branch. This repository publishes reference implementations rather than versioned release artifacts, so release branches are not maintained separately.
 
 ## Reporting vulnerabilities
 
 Do not open a public issue for suspected vulnerabilities, exploit details, or credential leaks.
 
 Report vulnerabilities through GitHub private vulnerability reporting:
-https://github.com/krotname/CodewarsKataJava/security/advisories/new
+https://github.com/krotname/JavaAlgorithmsShowcase/security/advisories/new
 
 Include:
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -4,7 +4,7 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-    <!-- Generated smoke wrappers intentionally stay close to the original kata surface. -->
+    <!-- Generated smoke wrappers intentionally stay close to the original API surface. -->
     <suppress
             files="[/\\]src[/\\]test[/\\]java[/\\](coderun|interview|kyu3|kyu4|kyu5|kyu6|kyu7|leetcode|other)[/\\](?!(AllMostPopularityKyu8Test|AnagramsTest|ArmstrongNumberTest|AverageElementTest|BattleFieldTest|BinaryArrayToNumberTest|BlockSequenceTest|BraceCheckerTest|BracketsTest|CallbackSchedulerTest|CompareTest|DigitalRootTest|DinglemouseTest|DirReductionTest|DistinctValueTest|ElementOccursMostOftenTest|FindMissingLetterTest|FindOddTest|FindOutlierTest|FindShortTest|FindUniqTest|GenerationOfBracketSequencesTest|HighAndLowTest|IntervalTest|LargestFiveDigitNumberTest|LikeItTest|MaximumSequenceWithOneZeroTest|MergeIntervalsTest|MetroTest|MoneyTest|MorseCodeDecoderTest|OrderWeightTest|PersistTest|PickPeaksTest|RailFenceCipherTest|RecursionMaxTest|RemovingDuplicatesYTest|ResistorColorCodes2Test|ReverseIntTest|RomanNumeralsTest|SequentialOneTest|SequentialOneYTest|StonesAndJewelryAlgorithmsTest|StonesAndJewelryTest|StreamMainTest|StringSplitTest|SumSquaredDivisorsTest|TemperatureServiceTest|TenMinWalkTest|TimeFormatterTest|TribonacciSequenceTest|ValidatePinTest|ValidParenthesesTest|VasyaClerkTest|VINCheckerTest|WhoIsNextTest|toCamelCaseTest|.*PropertyTest)\.java$).*Test\.java"
             checks=".*"/>

--- a/docs/assets/project-icon.svg
+++ b/docs/assets/project-icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
-  <title id="title">Codewars Kata Java</title>
-  <desc id="desc">Java kata practice mark with code brackets, tests, and quality gates.</desc>
+  <title id="title">Java Algorithms &amp; Reliability Showcase</title>
+  <desc id="desc">Java algorithms, tests, and reliability quality gates.</desc>
   <rect width="1200" height="630" fill="#101820"/>
   <rect x="80" y="70" width="1040" height="490" rx="36" fill="#f4f7fb"/>
   <path d="M345 230 230 315l115 85" fill="none" stroke="#0f766e" stroke-width="34" stroke-linecap="round" stroke-linejoin="round"/>
@@ -8,5 +8,5 @@
   <path d="M545 430 655 200" fill="none" stroke="#b42318" stroke-width="34" stroke-linecap="round"/>
   <circle cx="600" cy="315" r="72" fill="#f59e0b"/>
   <path d="M570 316h60M600 286v60" stroke="#101820" stroke-width="20" stroke-linecap="round"/>
-  <text x="600" y="505" text-anchor="middle" font-family="Segoe UI, Arial, sans-serif" font-size="56" font-weight="700" fill="#101820">Codewars Kata Java</text>
+  <text x="600" y="505" text-anchor="middle" font-family="Segoe UI, Arial, sans-serif" font-size="40" font-weight="700" fill="#101820">Java Algorithms &amp; Reliability Showcase</text>
 </svg>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>name.krot</groupId>
-    <artifactId>Codewars</artifactId>
+    <artifactId>java-algorithms-showcase</artifactId>
     <version>1.1</version>
-    <name>Codewars Solutions</name>
-    <description>Java kata solutions with tests and quality gates.</description>
-    <url>https://github.com/krotname/CodewarsKataJava</url>
+    <name>Java Algorithms &amp; Reliability Showcase</name>
+    <description>Java reference implementations for algorithms and transaction validation: property-based tests, CI, CodeQL, and static quality gates.</description>
+    <url>https://github.com/krotname/JavaAlgorithmsShowcase</url>
 
     <properties>
         <java.version>17</java.version>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-# Kata and algorithm exercise solutions naturally repeat short structural patterns.
-# Keep SonarCloud issue/security analysis, but exclude these training folders from CPD.
+# Source-derived algorithm implementations naturally repeat short structural patterns.
+# Keep SonarCloud issue/security analysis, but exclude these compatibility folders from CPD.
 sonar.cpd.exclusions=src/main/java/kyu*/**/*,src/main/java/algorithms/**/*,src/test/java/**/*,.github/**/*


### PR DESCRIPTION
## What changed
- repositioned both READMEs around selected algorithm and transaction-validation components
- replaced educational framing with an engineering showcase and moved source attribution to `Sources & provenance`
- updated Maven coordinates, project metadata, repository links, icon text, and public maintenance copy
- aligned documentation with the renamed `JavaAlgorithmsShowcase` repository

## Why
The previous repository name and README framing emphasized the learning source rather than the engineering evidence: deterministic APIs, edge cases, property-based testing, static analysis, and reproducible CI.

## Impact
Documentation and project metadata only; runtime behavior is unchanged. Internal `kyu*` packages remain intact for provenance and API compatibility.

## Validation
- `mvn -B verify`
- 594 tests passed
- JaCoCo thresholds passed
- Checkstyle, PMD, and SpotBugs passed