### PR TITLE
Establish Sonar new-code baseline for 1.2

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,11 +2,9 @@ name: Actionlint
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/**"
   push:
-    paths:
-      - ".github/workflows/**"
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>name.krot</groupId>
     <artifactId>java-algorithms-showcase</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <name>Java Algorithms &amp; Reliability Showcase</name>
     <description>Java reference implementations for algorithms and transaction validation: property-based tests, CI, CodeQL, and static quality gates.</description>
     <url>https://github.com/krotname/JavaAlgorithmsShowcase</url>


### PR DESCRIPTION
## Summary
- bump the Maven project version to 1.2
- use the completed 1.1 analysis as SonarCloud's previous-version baseline
- keep historical findings visible under Overall Code while enforcing the quality gate on future changes

## Verification
- mvn -B verify (597 tests, JaCoCo, Checkstyle, PMD, SpotBugs)