### PR TITLE
Declare Scorecard workflow default permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,9 @@ on:
     - cron: "23 3 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scorecard:
     name: OSSF Scorecards


### PR DESCRIPTION
## Summary
- set the workflow-level GitHub token default to contents: read`n- retain sensitive write permissions only on the Scorecard job
- satisfy both SonarCloud's explicit-permission rule and OpenSSF's least-privilege check

## Verification
- parsed every workflow YAML file successfully
- git diff --check