### PR TITLE
Harden CI credentialed uploads

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,9 +60,6 @@ jobs:
   verify:
     name: Maven Verify (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -97,8 +94,27 @@ jobs:
           path: target/site/jacoco
           if-no-files-found: warn
 
+  codecov:
+    name: Upload coverage to Codecov
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up JDK
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build trusted coverage report
+        run: mvn -B verify --file pom.xml
       - name: Upload coverage to Codecov
-        if: matrix.java == '21'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: target/site/jacoco/jacoco.xml

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,7 +47,7 @@ jobs:
 
   sonarcloud:
     name: SonarCloud analysis
-    if: github.actor != 'dependabot[bot]'
+    if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation
- Prevent credential exposure to untrusted pull-request code by ensuring SonarCloud and Codecov credentials/OIDC are not available to jobs that execute `mvn verify` on PR branches.

### Description
- Restrict SonarCloud analysis in `.github/workflows/quality.yml` to run only on trusted `push` events (change `if` to `github.event_name == 'push'`).
- Remove job-scoped `id-token: write` permission from the PR-capable Maven `verify` job in `.github/workflows/maven.yml` so that OIDC is not available during PR builds. 
- Add a new `codecov` job in `.github/workflows/maven.yml` that runs only on `push`, performs a trusted `mvn -B verify` there, and then uploads coverage with OIDC; this keeps credentialed uploads isolated to trusted events.

### Testing
- Loaded both workflow files with `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/quality.yml .github/workflows/maven.yml` which succeeded. 
- Ran `mvn -B -DskipTests validate --file pom.xml` which completed with `BUILD SUCCESS` indicating the project validates after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b12b04aec832788b5c13223b0b27b)