### PR TITLE
Validate sprint8 CLI input (Crib & PackedPrefix)

### DIFF
--- a/src/main/java/algorithms/sprint8/Crib.java
+++ b/src/main/java/algorithms/sprint8/Crib.java
@@ -35,12 +35,22 @@ import java.nio.charset.StandardCharsets;
 public class Crib {
 
     static boolean solve(String text, String[] words) {
-        int totalLength = 0;
-        for (String word : words) {
-            totalLength += word.length();
+        if (!isLowercaseWord(text)) {
+            return false;
         }
 
-        Trie trie = new Trie(totalLength + 1);
+        long totalLength = 0;
+        for (String word : words) {
+            if (!isLowercaseWord(word)) {
+                return false;
+            }
+            totalLength += word.length();
+            if (totalLength >= Integer.MAX_VALUE) {
+                return false;
+            }
+        }
+
+        Trie trie = new Trie((int) totalLength + 1);
         for (String word : words) {
             trie.add(word);
         }
@@ -74,6 +84,17 @@ public class Crib {
         }
 
         return dp[chars.length];
+    }
+
+    private static boolean isLowercaseWord(String word) {
+        for (int i = 0; i < word.length(); i++) {
+            char current = word.charAt(i);
+            if (current < 'a' || current > 'z') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static final class Trie {
@@ -207,6 +228,13 @@ public class Crib {
 
         String text = in.next();
         int n = in.nextInt();
+        if (n < 0) {
+            out.writeString("NO");
+            out.writeByte('\n');
+            out.flush();
+            return;
+        }
+
         String[] words = new String[n];
 
         for (int i = 0; i < n; i++) {

--- a/src/main/java/algorithms/sprint8/PackedPrefix.java
+++ b/src/main/java/algorithms/sprint8/PackedPrefix.java
@@ -40,12 +40,19 @@ public class PackedPrefix {
     private static final int MAX_UNPACKED_LENGTH = 100_000;
 
     static String solve(String[] packedStrings) {
+        if (packedStrings.length == 0 || !isValidPacked(packedStrings[0])) {
+            return "";
+        }
+
         String first = decodePrefix(packedStrings[0], MAX_UNPACKED_LENGTH);
         int prefixLength = first.length();
 
         for (int i = 1; i < packedStrings.length; i++) {
             if (prefixLength == 0) {
                 break;
+            }
+            if (!isValidPacked(packedStrings[i])) {
+                return "";
             }
             prefixLength = commonPrefixWithPacked(packedStrings[i], first, prefixLength);
         }
@@ -234,6 +241,45 @@ public class PackedPrefix {
         return matchingBracket;
     }
 
+    private static boolean isValidPacked(String packed) {
+        int top = 0;
+
+        for (int i = 0; i < packed.length(); i++) {
+            char current = packed.charAt(i);
+
+            if (current >= 'a' && current <= 'z') {
+                continue;
+            }
+
+            if (current >= '0' && current <= '9') {
+                if (i + 1 >= packed.length() || packed.charAt(i + 1) != '[') {
+                    return false;
+                }
+                continue;
+            }
+
+            if (current == '[') {
+                if (i == 0 || packed.charAt(i - 1) < '0' || packed.charAt(i - 1) > '9') {
+                    return false;
+                }
+                top++;
+                continue;
+            }
+
+            if (current == ']') {
+                if (top == 0) {
+                    return false;
+                }
+                top--;
+                continue;
+            }
+
+            return false;
+        }
+
+        return top == 0;
+    }
+
     // -------------------- FAST INPUT --------------------
     static final class FastIn {
         private final InputStream in;
@@ -357,7 +403,20 @@ public class PackedPrefix {
         FastOut out = new FastOut(System.out);
 
         int n = in.nextInt();
-        String first = decodePrefix(in.next(), MAX_UNPACKED_LENGTH);
+        if (n <= 0) {
+            out.writeByte('\n');
+            out.flush();
+            return;
+        }
+
+        String packedFirst = in.next();
+        if (!isValidPacked(packedFirst)) {
+            out.writeByte('\n');
+            out.flush();
+            return;
+        }
+
+        String first = decodePrefix(packedFirst, MAX_UNPACKED_LENGTH);
         int prefixLength = first.length();
 
         for (int i = 1; i < n; i++) {
@@ -366,6 +425,10 @@ public class PackedPrefix {
             }
 
             String packed = in.next();
+            if (!isValidPacked(packed)) {
+                prefixLength = 0;
+                break;
+            }
             prefixLength = commonPrefixWithPacked(packed, first, prefixLength);
         }
 


### PR DESCRIPTION
### Motivation
- The `Crib` and `PackedPrefix` CLI solvers assumed well-formed, lowercase input and unbounded dictionary sizes, which allowed crafted stdin to trigger uncaught runtime exceptions (e.g. `ArrayIndexOutOfBoundsException` and `NegativeArraySizeException`) and crash the process. 
- The change prevents availability issues by validating grammar, character ranges, bracket balance, and numeric bounds before using input as array indexes or allocation sizes.

### Description
- Added `isLowercaseWord` checks in `Crib.solve` to reject any `text` or dictionary `word` containing characters outside `'a'..'z'`, and changed the aggregate dictionary-size accumulator to `long` with a guard against overflow before allocating the trie. 
- Added an early check in `Crib.run` to reject negative `n` and return `NO` instead of allocating arrays with attacker-controlled sizes. 
- Added `isValidPacked` in `PackedPrefix` to validate encoded-string grammar (lowercase literals, digits followed by `'['`, bracket balance, no unmatched `]`, and disallowed characters) and applied it to the first and each subsequent packed string before decoding/comparison. 
- Hardened `PackedPrefix.run` to handle `n <= 0` and to stop/return early when invalid packed input is detected, avoiding use of `matchingBracket` or frame stacks on malformed strings.

### Testing
- Ran the full test suite with Maven using `mvn test` and observed `Tests run: 546, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbd02b1048327a7c41efb42149127)