### PR TITLE
Validate sprint7 solver input bounds

### DIFF
--- a/src/main/java/algorithms/sprint7/EqualSums.java
+++ b/src/main/java/algorithms/sprint7/EqualSums.java
@@ -31,18 +31,30 @@ import java.io.OutputStream;
 Пространственная сложность — O(S / 64).
 */
 public class EqualSums {
+    private static final int MAX_GAMES = 300;
+    private static final int MAX_TOTAL = MAX_GAMES * 300;
 
     static boolean solve(int[] points) {
-        int total = 0;
-        for (int point : points) {
-            total += point;
+        if (points.length > MAX_GAMES) {
+            throw new IllegalArgumentException("Too many games");
         }
 
-        if ((total & 1) == 1) {
+        long total = 0;
+        for (int point : points) {
+            if (point < 0) {
+                throw new IllegalArgumentException("Point value is out of range");
+            }
+            total += point;
+            if (total > MAX_TOTAL) {
+                throw new IllegalArgumentException("Total points are out of range");
+            }
+        }
+
+        if ((total & 1L) == 1L) {
             return false;
         }
 
-        int target = total / 2;
+        int target = (int) (total / 2);
         long[] reachable = new long[(target >> 6) + 1];
         reachable[0] = 1L;
 
@@ -168,10 +180,17 @@ public class EqualSums {
         FastOut out = new FastOut(System.out);
 
         int n = in.nextInt();
+        if (n < 0 || n > MAX_GAMES) {
+            throw new IOException("Number of games is out of range");
+        }
         int[] points = new int[n];
 
         for (int i = 0; i < n; i++) {
-            points[i] = in.nextInt();
+            int point = in.nextInt();
+            if (point < 0) {
+                throw new IOException("Point value is out of range");
+            }
+            points[i] = point;
         }
 
         out.writeAscii(solve(points) ? "True" : "False");

--- a/src/main/java/algorithms/sprint7/LevenshteinDistance.java
+++ b/src/main/java/algorithms/sprint7/LevenshteinDistance.java
@@ -27,8 +27,12 @@ import java.nio.charset.StandardCharsets;
 Пространственная сложность: O(min(n, m)), потому что хранится только две строки динамики.
 */
 public class LevenshteinDistance {
+    private static final int MAX_LINE_LENGTH = 1000;
 
     static int solve(String first, String second) {
+        if (first.length() > MAX_LINE_LENGTH || second.length() > MAX_LINE_LENGTH) {
+            throw new IllegalArgumentException("Input line is too long");
+        }
         String s = first;
         String t = second;
 
@@ -94,8 +98,8 @@ public class LevenshteinDistance {
             return buf[ptr++];
         }
 
-        String nextLine() throws IOException {
-            byte[] tmp = new byte[1024];
+        String nextLine(int maxLength) throws IOException {
+            byte[] tmp = new byte[Math.min(1024, maxLength + 1)];
             int size = 0;
             int c = read();
 
@@ -105,8 +109,11 @@ public class LevenshteinDistance {
 
             while (c != -1 && c != '\n') {
                 if (c != '\r') {
+                    if (size == maxLength) {
+                        throw new IOException("Input line is too long");
+                    }
                     if (size == tmp.length) {
-                        byte[] grown = new byte[tmp.length * 2];
+                        byte[] grown = new byte[Math.min(tmp.length * 2, maxLength)];
                         System.arraycopy(tmp, 0, grown, 0, tmp.length);
                         tmp = grown;
                     }
@@ -169,8 +176,8 @@ public class LevenshteinDistance {
         FastIn in = new FastIn(System.in);
         FastOut out = new FastOut(System.out);
 
-        String s = in.nextLine();
-        String t = in.nextLine();
+        String s = in.nextLine(MAX_LINE_LENGTH);
+        String t = in.nextLine(MAX_LINE_LENGTH);
 
         out.writeInt(solve(s, t));
         out.writeByte('\n');


### PR DESCRIPTION
### Motivation
- The sprint7 solvers trusted untrusted stdin sizes and contents, allowing negative or huge `n` to trigger `NegativeArraySizeException`/`OutOfMemoryError` and permitting integer overflow when accumulating point totals. 
- The Levenshtein solver buffered unbounded lines and does O(n*m) work with no input-size guard, enabling memory or CPU exhaustion on oversized inputs.

### Description
- Added `MAX_GAMES` and `MAX_TOTAL` limits and validated `points.length` and each `point` before use in `EqualSums`, and changed the accumulator to a `long` to avoid overflow when computing the bitmap `target` (then cast to `int`).
- Added checks in `EqualSums.run()` to validate `n` and per-point values read from stdin to avoid negative sizes or oversized allocations.
- Added `MAX_LINE_LENGTH` and pre-checks in `LevenshteinDistance.solve()` and changed `FastIn.nextLine()` to `nextLine(int maxLength)` which enforces a maximum line length and caps buffer growth to prevent unbounded buffering.
- Updated CLI usage to call the bounded `nextLine(MAX_LINE_LENGTH)` for both input lines in `LevenshteinDistance`.

### Testing
- Ran `mvn test` and the full test suite completed successfully after the changes. 
- Compiled the modified classes with `javac -d /tmp/ckj_classes src/main/java/algorithms/sprint7/EqualSums.java src/main/java/algorithms/sprint7/LevenshteinDistance.java` and exercised them via the CLI to confirm expected behavior for normal inputs. 
- Verified unsafe cases produce graceful errors instead of JVM crashes: negative `n` or overly large `n`/point totals in `EqualSums` return an IO/argument error rather than `NegativeArraySizeException`/`OutOfMemoryError`, and overly long lines to `LevenshteinDistance` produce an `Input line is too long` error instead of unbounded OOM or excessive CPU. 
- Performed quick smoke checks that the solvers still return correct results on representative valid inputs (examples executed via `java -cp /tmp/ckj_classes algorithms.sprint7.EqualSums` and `algorithms.sprint7.LevenshteinDistance`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf31007c8327b5f677534960159d)