### PR TITLE
Harden WaterWorld input dimensions

### DIFF
--- a/src/main/java/algorithms/sprint6/WaterWorld.java
+++ b/src/main/java/algorithms/sprint6/WaterWorld.java
@@ -32,8 +32,25 @@ import java.io.OutputStream;
 
 public class WaterWorld {
 
+    private static final int MAX_CELLS = 10_000_000;
+
+    private static int checkedTotalCells(int n, int m) {
+        if (n <= 0 || m <= 0) {
+            throw new IllegalArgumentException("Dimensions must be positive");
+        }
+
+        long total = (long) n * m;
+        if (total > MAX_CELLS) {
+            throw new IllegalArgumentException("Map is too large");
+        }
+        return (int) total;
+    }
+
     static int[] solve(byte[] map, int n, int m) {
-        int total = n * m;
+        int total = checkedTotalCells(n, m);
+        if (map.length != total) {
+            throw new IllegalArgumentException("Map size does not match dimensions");
+        }
         int[] queue = new int[total];
 
         int islandCount = 0;
@@ -130,10 +147,17 @@ public class WaterWorld {
 
             int val = 0;
             while (c > ' ') {
-                val = val * 10 + c - '0';
+                if (c < '0' || c > '9') {
+                    throw new IOException("Invalid integer token");
+                }
+                int digit = c - '0';
+                if (val > (Integer.MAX_VALUE - digit) / 10) {
+                    throw new IOException("Integer token is too large");
+                }
+                val = val * 10 + digit;
                 c = read();
             }
-            return val * sign;
+            return sign * val;
         }
 
         byte[] nextBytes(int length) throws IOException {
@@ -209,7 +233,8 @@ public class WaterWorld {
 
         int n = in.nextInt();
         int m = in.nextInt();
-        byte[] map = new byte[n * m];
+        int total = checkedTotalCells(n, m);
+        byte[] map = new byte[total];
 
         for (int row = 0; row < n; row++) {
             byte[] line = in.nextBytes(m);
@@ -288,7 +313,11 @@ public class WaterWorld {
         if (System.getProperty("os.name").startsWith("Windows")) {
             test();
         } else {
-            run();
+            try {
+                run();
+            } catch (IllegalArgumentException | IOException ignored) {
+                // Invalid input is rejected before allocating arrays.
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent process crashes and DoS caused by unchecked 32-bit multiplication and unvalidated CLI dimensions that could trigger `NegativeArraySizeException`, `ArrayIndexOutOfBoundsException`, or `OutOfMemoryError` when allocating the map or BFS queue. 
- Avoid silent integer-parser overflow and malformed numeric tokens that can produce attacker-controlled dangerous dimensions.

### Description
- Add a centralized validator `checkedTotalCells(n, m)` with a `MAX_CELLS` limit and use `long` multiplication to detect overflow and overly large maps, and throw `IllegalArgumentException` for invalid sizes. 
- Use the validated total in `solve` and `run`, and check `map.length` consistency before allocating the BFS queue. 
- Harden `FastIn.nextInt()` to reject non-digit characters and detect integer overflow while parsing, throwing `IOException` for invalid tokens. 
- Wrap the CLI `run()` invocation in `main` with a `try/catch` that ignores `IllegalArgumentException` and `IOException` so invalid input is rejected gracefully without performing large allocations.

### Testing
- Compiled the modified file with `javac -d /tmp/classes src/main/java/algorithms/sprint6/WaterWorld.java` and compilation succeeded. 
- Verified correct behavior on valid input using `printf '3 3\n#.#\n.#.\n#.#\n' | java -cp /tmp/classes algorithms.sprint6.WaterWorld` which produced the expected output. 
- Verified malicious inputs are rejected without crashing by running `printf '50000 50000\n' | java -cp /tmp/classes algorithms.sprint6.WaterWorld` and `printf '2147483648 1\n' | java -cp /tmp/classes algorithms.sprint6.WaterWorld`, both of which no longer trigger allocation crashes. 
- Ran project tests with `mvn test` (initial run failed due to a transient Maven Central `502 Bad Gateway` while resolving a dependency) and then retried `mvn -q test`, which completed (transient network failure noted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf304ec48327a3e4bfe506a19e3f)