### PR TITLE
Harden sprint4 CLI solvers against input-driven DoS and unbounded allocation

### DIFF
--- a/src/main/java/algorithms/sprint4/FindSystem.java
+++ b/src/main/java/algorithms/sprint4/FindSystem.java
@@ -9,10 +9,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
 
 // https://contest.yandex.ru/contest/24414/run-report/160043341/
 
 class FindSystem {
+
+    private static final int MAX_DOCUMENTS = 10_000;
+    private static final int MAX_QUERIES = 10_000;
+    private static final int MAX_LINE_LENGTH = 10_000;
 
     /*
      * Принцип работы алгоритма:
@@ -141,23 +147,24 @@ class FindSystem {
     private static void solve() throws Exception {
         FastReader reader = new FastReader(System.in);
 
-        int n = reader.nextInt();
+        int n = reader.nextInt(MAX_DOCUMENTS);
         String[] docs = new String[n];
         for (int i = 0; i < n; i++) {
-            docs[i] = reader.nextLine();
+            docs[i] = reader.nextLine(MAX_LINE_LENGTH);
         }
 
         HashMap<String, ArrayList<int[]>> index = buildIndex(docs);
 
-        int m = reader.nextInt();
-        StringBuilder out = new StringBuilder();
+        int m = reader.nextInt(MAX_QUERIES);
+        BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
 
         for (int i = 0; i < m; i++) {
-            String query = reader.nextLine();
-            out.append(processQuery(query, index)).append('\n');
+            String query = reader.nextLine(MAX_LINE_LENGTH);
+            out.write(processQuery(query, index));
+            out.newLine();
         }
 
-        System.out.print(out);
+        out.flush();
     }
 
     private static void test() {
@@ -205,7 +212,11 @@ class FindSystem {
         if (System.getProperty("os.name").startsWith("Windows")) {
             test();
         } else {
-            solve();
+            try {
+                solve();
+            } catch (IOException ignored) {
+                // Invalid or excessive input is rejected without exhausting memory or CPU.
+            }
         }
     }
     private static class FastReader {
@@ -229,7 +240,7 @@ class FindSystem {
             return buffer[ptr++];
         }
 
-        int nextInt() throws IOException {
+        int nextInt(int max) throws IOException {
             int c;
             do {
                 c = read();
@@ -238,15 +249,21 @@ class FindSystem {
                 }
             } while (c <= ' ');
 
-            int value = 0;
+            long value = 0;
             while (c > ' ') {
+                if (c < '0' || c > '9') {
+                    throw new IOException("Expected a non-negative integer");
+                }
                 value = value * 10 + c - '0';
+                if (value > max) {
+                    throw new IOException("Input value exceeds limit");
+                }
                 c = read();
             }
-            return value;
+            return (int) value;
         }
 
-        String nextLine() throws IOException {
+        String nextLine(int maxLength) throws IOException {
             int c = read();
 
             while (c == '\n' || c == '\r') {
@@ -255,6 +272,9 @@ class FindSystem {
 
             StringBuilder sb = new StringBuilder();
             while (c != -1 && c != '\n' && c != '\r') {
+                if (sb.length() == maxLength) {
+                    throw new IOException("Input line exceeds limit");
+                }
                 sb.append((char) c);
                 c = read();
             }

--- a/src/main/java/algorithms/sprint4/Map.java
+++ b/src/main/java/algorithms/sprint4/Map.java
@@ -1,9 +1,12 @@
 package algorithms.sprint4;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.util.OptionalInt;
+import java.util.concurrent.ThreadLocalRandom;
 
 // https://contest.yandex.ru/contest/24414/run-report/160371601/
 
@@ -51,6 +54,8 @@ public class Map {
      */
 
     private static final int SIZE = 100_003;
+    private static final int MAX_COMMANDS = 100_000;
+    private static final int HASH_SEED = ThreadLocalRandom.current().nextInt();
 
     static class Node {
         int key;
@@ -68,11 +73,9 @@ public class Map {
         Node[] buckets = new Node[SIZE];
 
         int index(int key) {
-            int x = key % SIZE;
-            if (x < 0) {
-                x += SIZE;
-            }
-            return x;
+            int mixed = key ^ HASH_SEED;
+            mixed ^= (mixed >>> 16);
+            return Math.floorMod(mixed, SIZE);
         }
 
         void put(int key, int value) {
@@ -144,8 +147,15 @@ public class Map {
         }
 
         int nextInt() throws IOException {
+            return nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+
+        int nextInt(int min, int max) throws IOException {
             int c = read();
             while (c <= ' ') {
+                if (c == -1) {
+                    throw new IOException("Unexpected end of input");
+                }
                 c = read();
             }
 
@@ -155,13 +165,24 @@ public class Map {
                 c = read();
             }
 
-            int num = 0;
+            if (c < '0' || c > '9') {
+                throw new IOException("Expected integer");
+            }
+
+            long num = 0;
             while (c > ' ') {
+                if (c < '0' || c > '9') {
+                    throw new IOException("Expected integer");
+                }
                 num = num * 10 + c - '0';
+                long signed = sign * num;
+                if (signed < min || signed > max) {
+                    throw new IOException("Input value exceeds limit");
+                }
                 c = read();
             }
 
-            return num * sign;
+            return (int) (num * sign);
         }
 
         char nextCommand() throws IOException {
@@ -181,11 +202,19 @@ public class Map {
     }
 
     public static void main(String[] args) throws Exception {
+        try {
+            solve();
+        } catch (IOException ignored) {
+            // Invalid or excessive input is rejected without exhausting memory or CPU.
+        }
+    }
+
+    private static void solve() throws IOException {
         Reader reader = new Reader();
         HashTable table = new HashTable();
-        StringBuilder out = new StringBuilder();
+        BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
 
-        int n = reader.nextInt();
+        int n = reader.nextInt(0, MAX_COMMANDS);
 
         for (int i = 0; i < n; i++) {
             char command = reader.nextCommand();
@@ -195,14 +224,18 @@ public class Map {
                 int value = reader.nextInt();
                 table.put(key, value);
             } else if (command == 'g') {
-                table.get(key).ifPresentOrElse(out::append, () -> out.append("None"));
-                out.append(System.lineSeparator());
+                OptionalInt result = table.get(key);
+                out.write(result.isPresent() ? String.valueOf(result.getAsInt()) : "None");
+                out.newLine();
+            } else if (command == 'd') {
+                OptionalInt result = table.delete(key);
+                out.write(result.isPresent() ? String.valueOf(result.getAsInt()) : "None");
+                out.newLine();
             } else {
-                table.delete(key).ifPresentOrElse(out::append, () -> out.append("None"));
-                out.append(System.lineSeparator());
+                throw new IOException("Unknown command");
             }
         }
 
-        System.out.print(out);
+        out.flush();
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent denial-of-service from attacker-controlled stdin sizes and predictable hash collisions in the sprint4 CLIs by adding bounds and unpredictability. 
- Avoid unbounded memory or CPU growth when these utilities are invoked on untrusted input. 

### Description
- For `Map`: add a per-process random `HASH_SEED` and mix keys before bucket selection to mitigate attacker-controlled collision chains, add `MAX_COMMANDS`, replace accumulated `StringBuilder` output with streamed `BufferedWriter`, add bounded and validated integer parsing (`nextInt(min,max)`), validate commands, and move CLI logic into `solve()` wrapped by a safe `main` that rejects invalid/excessive input. 
- For `FindSystem`: introduce `MAX_DOCUMENTS`, `MAX_QUERIES`, and `MAX_LINE_LENGTH`, enforce these limits in `nextInt(max)` and `nextLine(maxLength)`, stream per-query output with `BufferedWriter`, and catch `IOException` in `main` so oversized or malformed input is rejected without exhausting resources. 
- Keep original algorithms and data structures (chained hash table and inverted-index logic) but add defensive input handling and a randomized hash mapping to preserve functionality while reducing attack surface. 

### Testing
- Compiled both classes with `javac -d /tmp/cwjclasses src/main/java/algorithms/sprint4/Map.java src/main/java/algorithms/sprint4/FindSystem.java` and compilation succeeded. 
- Exercised CLIs with representative inputs for `algorithms.sprint4.Map` and `algorithms.sprint4.FindSystem` and observed expected outputs. 
- Verified oversized/malformed inputs are rejected (e.g. very large `n` now triggers a controlled `IOException` rather than exhausting heap). 
- Ran the full test suite with `mvn test` which completed successfully (`546` tests run, `0` failures/errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf30eb408327bfa1f037bdf137b3)