### PR TITLE
Fix deque index wraparound overflow

### DIFF
--- a/src/main/java/algorithms/sprint2/Deque.java
+++ b/src/main/java/algorithms/sprint2/Deque.java
@@ -68,11 +68,13 @@ public class Deque {
         }
 
         private int next(int i) {
-            return (i+1) % cap;
+            i++;
+            return i == cap ? 0 : i;
         }
 
         private int prev(int i) {
-            return (i-1+cap) % cap;
+            i--;
+            return i == -1 ? cap - 1 : i;
         }
 
         boolean isEmpty() {


### PR DESCRIPTION
### Motivation
- Prevent integer overflow in `prev()` for extremely large capacities where the expression `(i-1+cap) % cap` can overflow to a negative value and lead to `ArrayIndexOutOfBoundsException` during deque operations.

### Description
- Replace modulo-based wraparound in `RingDeque.next` and `RingDeque.prev` with branch-based increment/decrement logic (`i++; return i == cap ? 0 : i;` and `i--; return i == -1 ? cap - 1 : i;`) to preserve circular-buffer semantics without risking overflow.

### Testing
- Compiled and ran the code with `javac -d /tmp/codewars-classes src/main/java/algorithms/sprint2/Deque.java`, executed the internal test via `java -cp /tmp/codewars-classes -Dos.name=Windows -ea algorithms.sprint2.Deque` which printed `Test OK`, exercised the sample CLI input via `printf '4\n4\npush_front 861\npush_front -819\npop_back\npop_back\n' | java -cp /tmp/codewars-classes algorithms.sprint2.Deque`, and ran a reflection-based `DequePrevCheck` that verifies `prev(1_073_741_824)` with `cap=1_073_741_825`, and all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf3139c483278ffeff79bd4719d9)