### PR TITLE
Validate deque capacity before allocation

### DIFF
--- a/src/main/java/algorithms/sprint2/Deque.java
+++ b/src/main/java/algorithms/sprint2/Deque.java
@@ -55,6 +55,8 @@ import java.nio.charset.StandardCharsets;
 public class Deque {
 
     // -------------------- RING BUFFER DEQUE --------------------
+    private static final int MAX_CAPACITY = 100_000;
+
     static final class RingDeque {
         private final int[] a;
         private final int cap;
@@ -63,8 +65,8 @@ public class Deque {
         private int size = 0;
 
         RingDeque(int cap) {
-            this.cap = cap;
-            this.a = new int[cap];
+            this.cap = safeCapacity(cap);
+            this.a = new int[this.cap];
         }
 
         private int next(int i) {
@@ -108,6 +110,13 @@ public class Deque {
             size--;
             return x;
         }
+    }
+
+    private static int safeCapacity(int cap) {
+        if (cap < 0) {
+            return 0;
+        }
+        return Math.min(cap, MAX_CAPACITY);
     }
 
     private static void process(FastIn in, FastOut out) throws Exception {
@@ -229,6 +238,27 @@ public class Deque {
                                 "push_front 1\n" +
                                 "push_back 2\n" +
                                 "pop_back\n" +
+                                "pop_front\n"
+                )
+        );
+
+        // Некорректная емкость из ввода не должна приводить к аварийному завершению
+        assertEq(
+                "error\nerror\n",
+                solveIO(
+                        "2\n" +
+                                "-1\n" +
+                                "push_back 1\n" +
+                                "pop_front\n"
+                )
+        );
+
+        // Слишком большая емкость ограничивается безопасным максимумом до выделения массива
+        assertEq(
+                "error\n",
+                solveIO(
+                        "1\n" +
+                                "1000000000\n" +
                                 "pop_front\n"
                 )
         );


### PR DESCRIPTION
### Motivation
- Fix an availability vulnerability where the deque capacity read from stdin was used directly in `new int[cap]`, allowing `NegativeArraySizeException` for negative input and `OutOfMemoryError` for very large input. 
- Ensure the CLI kata does not crash or destabilize a shared judge process when given malformed or adversarial stdin.

### Description
- Introduce a `MAX_CAPACITY` bound (`100_000`) and a `safeCapacity(int)` helper to normalize capacities before allocation in `src/main/java/algorithms/sprint2/Deque.java`. 
- Replace the direct allocation `new int[cap]` with `new int[this.cap]` where `this.cap` is the sanitized value returned by `safeCapacity`. 
- Treat negative capacities as `0` and cap excessively large capacities to `MAX_CAPACITY` to avoid allocating uncontrolled memory. 
- Add in-file regression checks exercising negative and very large input cases so malformed stdin produces controlled `error` outputs instead of crashing. 

### Testing
- Compiled the class with `javac -d /tmp/deque-classes src/main/java/algorithms/sprint2/Deque.java` and the compilation succeeded. 
- Ran the built tests with `java -Dos.name=Windows -cp /tmp/deque-classes algorithms.sprint2.Deque` which printed `Test OK`, indicating existing tests pass. 
- Reproduced malformed inputs by piping `1\n-1\npop_front\n` and `0\n1000000000\n` to the program (the latter with `-Xmx32m`) and observed controlled `error` outputs without `NegativeArraySizeException` or `OutOfMemoryError`, confirming the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf302d888327905e44f7e02b9606)