### PR TITLE
Harden Solution2 stdin handling

### DIFF
--- a/src/main/java/algorithms/sprint1/Solution2.java
+++ b/src/main/java/algorithms/sprint1/Solution2.java
@@ -5,10 +5,13 @@ import static common.SafeParse.parseInt;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 public class Solution2 {
+    private static final int MAX_LINE_COUNT = 1_000_000;
+
     public static void solution(Node<String> head) {
         StringBuilder output = new StringBuilder();
         Node<String> current = head;
@@ -35,16 +38,47 @@ public class Solution2 {
     }
 
     public static void main(String[] args) throws IOException {
-        StringBuilder outputBuffer = new StringBuilder();
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
-        int lineCount = parseInt(reader.readLine());
+        int lineCount = readLineCount(reader);
+        PrintWriter writer = new PrintWriter(System.out, false, StandardCharsets.UTF_8);
         for (int i = 0; i < lineCount; ++i) {
-            StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
-            int firstValue = parseInt(tokenizer.nextToken());
-            int secondValue = parseInt(tokenizer.nextToken());
-            int result = firstValue + secondValue;
-            outputBuffer.append(result).append("\n");
+            StringTokenizer tokenizer = new StringTokenizer(readInputLine(reader, i + 1));
+            int firstValue = parseInt(nextToken(tokenizer, i + 1));
+            int secondValue = parseInt(nextToken(tokenizer, i + 1));
+            if (tokenizer.hasMoreTokens()) {
+                throw new IllegalArgumentException("Line " + (i + 1) + " must contain exactly two integers");
+            }
+            int result = Math.addExact(firstValue, secondValue);
+            writer.println(result);
         }
-        System.out.println(outputBuffer);
+        writer.println();
+        writer.flush();
+    }
+
+    private static int readLineCount(BufferedReader reader) throws IOException {
+        String countLine = reader.readLine();
+        if (countLine == null) {
+            throw new IllegalArgumentException("Missing line count");
+        }
+        int lineCount = parseInt(countLine);
+        if (lineCount < 0 || lineCount > MAX_LINE_COUNT) {
+            throw new IllegalArgumentException("Line count must be between 0 and " + MAX_LINE_COUNT);
+        }
+        return lineCount;
+    }
+
+    private static String readInputLine(BufferedReader reader, int lineNumber) throws IOException {
+        String inputLine = reader.readLine();
+        if (inputLine == null) {
+            throw new IllegalArgumentException("Missing input line " + lineNumber);
+        }
+        return inputLine;
+    }
+
+    private static String nextToken(StringTokenizer tokenizer, int lineNumber) {
+        if (!tokenizer.hasMoreTokens()) {
+            throw new IllegalArgumentException("Line " + lineNumber + " must contain exactly two integers");
+        }
+        return tokenizer.nextToken();
     }
 }

--- a/src/test/java/algorithms/AlgorithmCliTest.java
+++ b/src/test/java/algorithms/AlgorithmCliTest.java
@@ -1,6 +1,7 @@
 package algorithms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.ByteArrayInputStream;
@@ -31,6 +32,22 @@ class AlgorithmCliTest {
             String expectedOutput) throws Exception {
 
         assertEquals(normalizeLines(expectedOutput), normalizeLines(invokeWithStdio(className, methodName, input)));
+    }
+
+    @Test
+    void solution2RejectsMissingInputLine() {
+        assertThrows(IllegalArgumentException.class, () -> invokeWithStdio(
+                "algorithms.sprint1.Solution2",
+                "main",
+                "2%n1 2%n".formatted()));
+    }
+
+    @Test
+    void solution2RejectsOversizedLineCount() {
+        assertThrows(IllegalArgumentException.class, () -> invokeWithStdio(
+                "algorithms.sprint1.Solution2",
+                "main",
+                "1000001%n".formatted()));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Prevent uncaught `NullPointerException` when the declared stdin line count does not match supplied input. 
- Avoid unbounded memory allocation from accumulating all outputs in a single `StringBuilder`, which can lead to OOM for attacker-controlled large input. 
- Enforce token and numeric validation to avoid malformed input being silently processed or causing unexpected behavior.

### Description
- Added `MAX_LINE_COUNT` limit and `readLineCount`, `readInputLine`, and `nextToken` helpers to validate the declared line count, EOF, and token availability in `src/main/java/algorithms/sprint1/Solution2.java`.
- Replaced output accumulation with streaming to stdout using a `PrintWriter` to eliminate unbounded `StringBuilder` growth and preserved the expected trailing blank line.
- Validated token counts and numeric parsing, replaced addition with `Math.addExact` for safer arithmetic, and throw `IllegalArgumentException` on malformed input.
- Added regression tests in `src/test/java/algorithms/AlgorithmCliTest.java` to assert that missing input lines and oversized line counts are rejected.

### Testing
- Ran `mvn -q -Dtest=AlgorithmCliTest test`, which passed after the fix. 
- Ran `mvn -q test`, which completed successfully. 
- Ran `mvn -q verify`, which completed successfully and includes the new integration checks for `Solution2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf30f5988327ae9cc5d470702c83)