### PR TITLE
Prevent stack overflow in BST deletion

### DIFF
--- a/src/main/java/algorithms/sprint5/Solution.java
+++ b/src/main/java/algorithms/sprint5/Solution.java
@@ -26,7 +26,7 @@ public class Solution {
      *
      * Почему алгоритм корректен:
      * 1) По свойству BST искомый ключ может находиться только
-     *    в одном из двух поддеревьев, поэтому рекурсивный спуск
+     *    в одном из двух поддеревьев, поэтому спуск
      *    идёт ровно по нужному пути.
      *
      * 2) Если у удаляемой вершины не более одного ребёнка,
@@ -46,43 +46,49 @@ public class Solution {
      * Временная сложность: O(h), где h — высота дерева,
      * что в худшем случае даёт O(n), где n — число узлов в дереве.
      *
-     * Дополнительная пространственная сложность: O(h) из-за стека рекурсии,
-     * что в худшем случае даёт O(n).
+     * Дополнительная пространственная сложность: O(1), поскольку обход
+     * выполняется итеративно.
      */
 
     public static Node remove(Node root, int key) {
-        if (root == null) {
-            return null;
+        Node parent = null;
+        Node current = root;
+
+        while (current != null && current.getValue() != key) {
+            parent = current;
+            current = key < current.getValue() ? current.getLeft() : current.getRight();
         }
 
-        if (key < root.getValue()) {
-            root.setLeft(remove(root.getLeft(), key));
+        if (current == null) {
             return root;
         }
 
-        if (key > root.getValue()) {
-            root.setRight(remove(root.getRight(), key));
+        if (current.getLeft() != null && current.getRight() != null) {
+            Node predecessorParent = current;
+            Node predecessor = current.getLeft();
+            while (predecessor.getRight() != null) {
+                predecessorParent = predecessor;
+                predecessor = predecessor.getRight();
+            }
+
+            current.setValue(predecessor.getValue());
+            if (predecessorParent == current) {
+                predecessorParent.setLeft(predecessor.getLeft());
+            } else {
+                predecessorParent.setRight(predecessor.getLeft());
+            }
             return root;
         }
 
-        if (root.getLeft() == null) {
-            return root.getRight();
+        Node replacement = current.getLeft() != null ? current.getLeft() : current.getRight();
+        if (parent == null) {
+            return replacement;
         }
-
-        if (root.getRight() == null) {
-            return root.getLeft();
+        if (parent.getLeft() == current) {
+            parent.setLeft(replacement);
+        } else {
+            parent.setRight(replacement);
         }
-
-        Node predecessor = findMax(root.getLeft());
-        root.setValue(predecessor.getValue());
-        root.setLeft(remove(root.getLeft(), predecessor.getValue()));
         return root;
-    }
-
-    private static Node findMax(Node node) {
-        while (node.getRight() != null) {
-            node = node.getRight();
-        }
-        return node;
     }
 }

--- a/src/test/java/algorithms/sprint5/SolutionTest.java
+++ b/src/test/java/algorithms/sprint5/SolutionTest.java
@@ -51,6 +51,28 @@ class SolutionTest {
         assertEquals(5, result.getRight().getValue());
     }
 
+    @Test
+    void removeHandlesDeepSkewedTreeWithoutOverflowingStack() {
+        Node root = node(null, null, 0);
+        Node current = root;
+        for (int value = 1; value < 100_000; value++) {
+            Node next = node(null, null, value);
+            current.setRight(next);
+            current = next;
+        }
+
+        Node result = Solution.remove(root, 99_999);
+
+        assertEquals(0, result.getValue());
+        assertNull(current.getRight());
+        current = result;
+        for (int value = 0; value < 99_999; value++) {
+            assertEquals(value, current.getValue());
+            current = current.getRight();
+        }
+        assertNull(current);
+    }
+
     private static Node node(Node left, Node right, int value) {
         return new Node(left, right, value);
     }


### PR DESCRIPTION
### Motivation
- The public `Solution.remove(Node,int)` implementation used unbounded recursion proportional to tree height, which can trigger `StackOverflowError` on deeply skewed (attacker-controlled) trees and cause availability failures.
- The goal is to eliminate the recursive stack growth while preserving existing deletion semantics (leaf, one-child, two-child using predecessor) and tests.

### Description
- Replace recursive lookup-and-delete with an iterative search using `parent` and `current` pointers to avoid per-level Java stack frames during traversal.
- Handle nodes with two children by locating and detaching the predecessor iteratively (no recursive call) and copying its value to the deleted node, preserving predecessor-based behavior.
- Remove the recursive `findMax`/recursive-delete path and return/update child links iteratively; overall auxiliary space becomes O(1).
- Add a regression test `removeHandlesDeepSkewedTreeWithoutOverflowingStack` that constructs a 100,000-node right-skewed tree and deletes the deepest node to verify no stack overflow and correct tree shape.

### Testing
- Ran `mvn -Dtest=algorithms.sprint5.SolutionTest test`, and the module-specific tests passed (5 tests, all successful).
- Ran full test suite with `mvn test`, and all automated tests passed (598 tests, all successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb511c8e88327ab8b0a47cdc2ab39)