### PR TITLE
Handle malformed RPN calculator input safely

### DIFF
--- a/src/main/java/algorithms/sprint2/Calculator.java
+++ b/src/main/java/algorithms/sprint2/Calculator.java
@@ -45,8 +45,15 @@ public class Calculator {
             if (t.length() == 1) {
                 char op = t.charAt(0);
                 if (op == '+' || op == '-' || op == '*' || op == '/') {
+                    if (st.size() < 2) {
+                        throw new IllegalArgumentException("Operator requires two operands: " + op);
+                    }
                     int b = st.pop();
                     int a = st.pop();
+
+                    if (op == '/' && b == 0) {
+                        throw new IllegalArgumentException("Division by zero");
+                    }
 
                     int r;
                     if (op == '+') {
@@ -64,9 +71,16 @@ public class Calculator {
                 }
             }
 
-            st.push(parseInt(t));
+            try {
+                st.push(parseInt(t));
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException("Invalid token: " + t, exception);
+            }
         }
 
+        if (st.size() != 1) {
+            throw new IllegalArgumentException("Expression must produce exactly one result");
+        }
         return st.peek();
     }
 
@@ -74,7 +88,13 @@ public class Calculator {
         FastIn in = new FastIn(System.in);
         FastOut out = new FastOut(System.out);
 
-        int ans = eval(in);
+        final int ans;
+        try {
+            ans = eval(in);
+        } catch (IllegalArgumentException exception) {
+            System.err.println("Invalid expression: " + exception.getMessage());
+            return;
+        }
 
         out.writeInt(ans);
         out.writeByte('\n');

--- a/src/test/java/algorithms/AlgorithmCliTest.java
+++ b/src/test/java/algorithms/AlgorithmCliTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Tag("integration")
 class AlgorithmCliTest {
@@ -48,6 +49,12 @@ class AlgorithmCliTest {
             Files.deleteIfExists(input);
             Files.deleteIfExists(output);
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"+", "", "1 0 /", "abc", "1 2"})
+    void calculatorRejectsMalformedExpressionsWithoutThrowing(String input) throws Exception {
+        assertEquals("", invokeWithStdio("algorithms.sprint2.Calculator", "run", input));
     }
 
     private static Stream<Arguments> stdioCases() {


### PR DESCRIPTION
### Motivation
- The CLI `Calculator` previously assumed well-formed RPN tokens and performed unchecked stack pops, division, and integer parsing which allowed malformed stdin (e.g. `+`, empty input, `1 0 /`, `abc`, or extra operands) to throw runtime exceptions and terminate the process. The change prevents these crash/availability paths by validating untrusted input.

### Description
- Validate operand counts before applying an operator by checking `st.size() < 2` and reject with a controlled error instead of performing unchecked `pop()` calls in `eval` (`src/main/java/algorithms/sprint2/Calculator.java`).
- Detect division-by-zero before calling `Math.floorDiv` and reject with a clear error message.
- Convert invalid numeric tokens by wrapping `parseInt` in a try/catch and rethrowing as `IllegalArgumentException`, and require the final stack size to be exactly one before returning the result.
- Handle `IllegalArgumentException` at the CLI boundary in `run()` by printing a short diagnostic to `stderr` and returning instead of allowing stack/parse/arithmetic exceptions to propagate.
- Add regression coverage for malformed inputs by adding a parameterized test to `src/test/java/algorithms/AlgorithmCliTest.java` that verifies the `Calculator` rejects `+`, empty input, `1 0 /`, `abc`, and an extra-operand case.

### Testing
- Ran `mvn -q -Dtest=algorithms.AlgorithmCliTest test` and the test suite for the modified integration case completed successfully.
- Ran `mvn -q test` to execute the full test suite and it completed without failures.
- Ran `mvn -q checkstyle:check` and code passes the project's checkstyle rules.
- Ran `git diff --check` to ensure no whitespace or patch issues and it reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627aa488327a21e1bda48e5411c)