### PR TITLE
Handle empty input in Distances

### DIFF
--- a/src/main/java/algorithms/sprint1/Distances.java
+++ b/src/main/java/algorithms/sprint1/Distances.java
@@ -17,6 +17,7 @@ public class Distances {
     static int[] solve(int[] a) {
         int n = a.length;
         int[] dist = new int[n];
+        if (n == 0) return dist;
 
         int lastZero = -n;
         for (int i = 0; i < n; i++) {
@@ -149,6 +150,7 @@ public class Distances {
     }
 
     static void test() {
+        assertEq(new int[]{}, solve(new int[]{}), "empty");
         assertEq(new int[]{0, 1, 2, 1, 0}, solve(new int[]{0, 1, 4, 9, 0}), "sample1");
         assertEq(new int[]{0, 1, 2, 3, 4, 5}, solve(new int[]{0, 7, 9, 4, 8, 20}), "sample2");
         assertEq(new int[]{0}, solve(new int[]{0}), "n=1");


### PR DESCRIPTION
### Motivation
- Fix a regression where `Distances.solve()` crashed with `ArrayIndexOutOfBoundsException` for an empty input array (`n == 0`) due to the sentinel-based backward scan starting at index 0.

### Description
- Return the empty `dist` early in `Distances.solve()` with `if (n == 0) return dist;` and add an empty-array assertion `assertEq(new int[]{}, solve(new int[]{}), "empty");` to the class's built-in tests in `src/main/java/algorithms/sprint1/Distances.java` to prevent the regression while preserving existing logic.

### Testing
- Ran the full test suite with `mvn test` (all tests passed: 597 tests, build SUCCESS) and executed the class-level `test()` check via `java -Dos.name=Windows -cp target/classes algorithms.sprint1.Distances` which printed `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627c10083278cb4b1bef3e50fc2)