### PR TITLE
Harden Distances input and output handling

### DIFF
--- a/src/main/java/algorithms/sprint1/Distances.java
+++ b/src/main/java/algorithms/sprint1/Distances.java
@@ -3,8 +3,6 @@ package algorithms.sprint1;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.EOFException;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -12,6 +10,7 @@ import java.util.Arrays;
 
 // https://contest.yandex.ru/contest/22450/run-report/157289807/
 public class Distances {
+    private static final int MAX_INPUT_SIZE = 100_000;
 
     // -------------------- SOLUTION --------------------
     static int[] solve(int[] a) {
@@ -113,18 +112,20 @@ public class Distances {
         void flush() throws IOException {
             out.write(buf, 0, p);
             p = 0;
+            out.flush();
         }
     }
 
     // -------------------- INPUT / OUTPUT --------------------
-    static void run() {
-
-        try (InputStream input = new BufferedInputStream(new FileInputStream("input.txt"));
-             OutputStream output = new BufferedOutputStream(new FileOutputStream("output.txt"))) {
-            FastIn in = new FastIn(input);
-            FastOut out = new FastOut(output);
+    static void run(InputStream input, OutputStream output) {
+        try {
+            FastIn in = new FastIn(new BufferedInputStream(input));
+            FastOut out = new FastOut(new BufferedOutputStream(output));
 
             int n = in.nextInt();
+            if (n < 1 || n > MAX_INPUT_SIZE) {
+                throw new IllegalArgumentException("Input size must be between 1 and " + MAX_INPUT_SIZE);
+            }
             int[] a = new int[n];
             for (int i = 0; i < n; i++) a[i] = in.nextInt();
 
@@ -139,6 +140,10 @@ public class Distances {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static void run() {
+        run(System.in, System.out);
     }
 
     // -------------------- TESTS --------------------

--- a/src/test/java/algorithms/AlgorithmCliTest.java
+++ b/src/test/java/algorithms/AlgorithmCliTest.java
@@ -10,11 +10,8 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,23 +30,6 @@ class AlgorithmCliTest {
         assertEquals(normalizeLines(expectedOutput), normalizeLines(invokeWithStdio(className, methodName, input)));
     }
 
-    @Test
-    void distancesRunReadsAndWritesContestFiles() throws Exception {
-        Path input = Path.of("input.txt");
-        Path output = Path.of("output.txt");
-        Files.writeString(input, "5%n0 1 4 9 0%n".formatted(), StandardCharsets.UTF_8);
-        Files.deleteIfExists(output);
-
-        try {
-            invokeNoArg("algorithms.sprint1.Distances", "run");
-
-            assertEquals("0 1 2 1 0\n", normalizeLines(Files.readString(output, StandardCharsets.UTF_8)));
-        } finally {
-            Files.deleteIfExists(input);
-            Files.deleteIfExists(output);
-        }
-    }
-
     private static Stream<Arguments> stdioCases() {
         return Stream.of(
                 arguments("algorithms.sprint0.SlidingAverage", "main",
@@ -61,6 +41,9 @@ class AlgorithmCliTest {
                 arguments("algorithms.sprint1.SleightOfHand", "run",
                         "3%n1231%n2..2%n2..2%n2..2%n".formatted(),
                         "2%n".formatted()),
+                arguments("algorithms.sprint1.Distances", "run",
+                        "5%n0 1 4 9 0%n".formatted(),
+                        "0 1 2 1 0%n".formatted()),
                 arguments("algorithms.sprint1.Solution2", "main",
                         "2%n1 2%n3 4%n".formatted(),
                         "3%n7%n%n".formatted()),
@@ -152,10 +135,6 @@ class AlgorithmCliTest {
             System.setIn(oldIn);
             System.setOut(oldOut);
         }
-    }
-
-    private static void invokeNoArg(String className, String methodName) throws Exception {
-        invoke(className, methodName);
     }
 
     private static void invoke(String className, String methodName) throws Exception {

--- a/src/test/java/algorithms/sprint1/DistancesTest.java
+++ b/src/test/java/algorithms/sprint1/DistancesTest.java
@@ -1,0 +1,38 @@
+package algorithms.sprint1;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DistancesTest {
+
+    @Test
+    void readsAndWritesThroughProvidedStreams() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        Distances.run(input("5 0 1 4 9 0"), output);
+
+        assertEquals("0 1 2 1 0\n", output.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void rejectsNegativeInputSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Distances.run(input("-1"), new ByteArrayOutputStream()));
+    }
+
+    @Test
+    void rejectsExcessiveInputSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Distances.run(input("100001"), new ByteArrayOutputStream()));
+    }
+
+    private static ByteArrayInputStream input(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent local file-clobbering via fixed `output.txt` and unbounded array allocation from attacker-controlled input by removing fixed-path file I/O and validating sizes.
- Preserve existing algorithm behavior and contest-style entrypoint while removing unsafe defaults that follow symlinks and allow NegativeArraySizeException/OutOfMemoryError.

### Description

- Replaced fixed `new FileInputStream("input.txt")` / `new FileOutputStream("output.txt")` usage by adding `run(InputStream, OutputStream)` and delegating the no-arg `run()` to `run(System.in, System.out)` so callers supply streams.
- Added `private static final int MAX_INPUT_SIZE = 100_000` and validate `n` with `if (n < 1 || n > MAX_INPUT_SIZE)` to reject negative, zero, or excessive sizes before allocating the `int[]`.
- Ensured buffered output is fully propagated by calling the underlying stream's `flush()` from `FastOut.flush()`.
- Added focused tests: `src/test/java/algorithms/sprint1/DistancesTest.java` for normal stream I/O and invalid sizes, and updated `AlgorithmCliTest` to exercise `Distances.run` via standard I/O instead of contest files.

### Testing

- Ran `git diff --check` with no reported whitespace problems.
- Executed `mvn -q -Dtest=algorithms.sprint1.DistancesTest test`, which passed the new unit tests.
- Executed `mvn -q verify`, and the full test suite completed successfully (integration and unit tests passed; Maven emitted only a non-failing JDK/deprecation warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627a6e88327bd854621ee5f04c0)