### PR TITLE
Harden AverageElement against malformed and oversized input

### DIFF
--- a/src/main/java/coderun/AverageElement.java
+++ b/src/main/java/coderun/AverageElement.java
@@ -3,7 +3,6 @@ package coderun;
 
 import static common.SafeParse.parseInt;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -11,11 +10,12 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 
 
 public class AverageElement {
+
+    private static final int MAX_INPUT_CHARACTERS = 4096;
 
     /**
      * Для чтения входных данных необходимо получить их
@@ -58,26 +58,52 @@ public class AverageElement {
     }
 
     static void solve(Reader input, Writer output) throws IOException {
-        BufferedReader reader = new BufferedReader(input);
         BufferedWriter writer = new BufferedWriter(output);
-        String line = reader.readLine();
-        if (line == null) {
+        String line = readBoundedLine(input);
+        if (line == null || line.isBlank()) {
             return;
         }
         String[] parts = line.trim().split("\\s+");
 
-        writer.write(String.valueOf(average(parts)));
+        try {
+            writer.write(String.valueOf(average(parts)));
+        } catch (IllegalArgumentException ignored) {
+            return;
+        }
         writer.flush();
     }
 
     static Integer average(String[] list) {
-        return Arrays
-                .stream(list)
-                .sequential()
-                .map(AverageElement::parseInteger)
-                .sorted()
-                .toList()
-                .get(1);
+        if (list.length < 2) {
+            throw new IllegalArgumentException("At least two integers are required");
+        }
+
+        int smallest = Integer.MAX_VALUE;
+        int secondSmallest = Integer.MAX_VALUE;
+        for (String value : list) {
+            int number = parseInteger(value);
+            if (number < smallest) {
+                secondSmallest = smallest;
+                smallest = number;
+            } else if (number < secondSmallest) {
+                secondSmallest = number;
+            }
+        }
+        return secondSmallest;
+    }
+
+    private static String readBoundedLine(Reader input) throws IOException {
+        StringBuilder line = new StringBuilder();
+        for (int character = input.read(); character != -1 && character != '\n'; character = input.read()) {
+            if (character == '\r') {
+                break;
+            }
+            if (line.length() == MAX_INPUT_CHARACTERS) {
+                return null;
+            }
+            line.append((char) character);
+        }
+        return line.isEmpty() ? null : line.toString();
     }
 
     private static Integer parseInteger(String value) {

--- a/src/test/java/coderun/AverageElementTest.java
+++ b/src/test/java/coderun/AverageElementTest.java
@@ -29,4 +29,31 @@ class AverageElementTest {
 
         assertEquals("5", output.toString());
     }
+
+    @Test
+    void shouldIgnoreInvalidOrInsufficientInput() throws IOException {
+        assertProducesNoOutput("");
+        assertProducesNoOutput("   ");
+        assertProducesNoOutput("5");
+        assertProducesNoOutput("1 invalid 3");
+    }
+
+    @Test
+    void shouldRejectAnOversizedInputLine() throws IOException {
+        assertProducesNoOutput("1 ".repeat(2049));
+    }
+
+    @Test
+    void shouldFindSecondValueWithoutSortingTheInput() {
+        assertEquals(2, AverageElement.average(new String[]{"4", "2", "3", "1"}));
+        assertEquals(1, AverageElement.average(new String[]{"1", "1"}));
+    }
+
+    private static void assertProducesNoOutput(String input) throws IOException {
+        StringWriter output = new StringWriter();
+
+        AverageElement.solve(new StringReader(input), output);
+
+        assertEquals("", output.toString());
+    }
 }


### PR DESCRIPTION
### Motivation

- The CLI solver accepted a single unbounded stdin line and immediately split and parsed every token with `Integer.valueOf`, which allowed EOF, blank, non-numeric tokens, too-few tokens, and extremely long lines to crash or exhaust resources. 
- The previous implementation materialized and sorted the entire input before accessing the second element, enabling memory/CPU exhaustion on attacker-controlled input. 
- The change aims to make input handling robust and to compute the required result without unbounded allocation while preserving the original semantics for valid inputs.

### Description

- Bound stdin processing by adding `MAX_INPUT_CHARACTERS = 4096` and a `readBoundedLine(Reader)` helper that returns `null` for EOF, blank, or oversized lines. 
- Change `solve(Reader, Writer)` to use the bounded reader, normalize whitespace with `split("\\s+")`, and silently ignore invalid, blank, undersized, or oversized input by returning early. 
- Replace stream-based parsing + sorting + `toList().get(1)` with a linear, constant-space algorithm that scans parsed integers once to compute the second-smallest value and throws `IllegalArgumentException` for fewer than two values. 
- Add regression tests in `src/test/java/coderun/AverageElementTest.java` covering empty/blank input, single-value input, non-numeric tokens, oversized input, duplicates, and multi-value behavior, and keep whitespace-normalization test.

### Testing

- Ran the specific unit tests with `mvn -q -Dtest=coderun.AverageElementTest test` and they passed. 
- Ran the full test suite with `mvn -q test` and it completed successfully. 
- Verified no `git diff --check` issues were reported after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb62770f0832791e70f10f5866523)