### PR TITLE
Prevent EncryptThis failures on blank tokens

### DIFF
--- a/src/main/java/kyu6/EncryptThis.java
+++ b/src/main/java/kyu6/EncryptThis.java
@@ -7,9 +7,9 @@ public class EncryptThis {
     //6 https://www.codewars.com/kata/5848565e273af816fb000449/train/java
 
     public static String encryptThis(String text) {
-        if (text == null || text.isEmpty()) return "";
+        if (text == null || text.isBlank()) return "";
         StringBuilder stringBuilder = new StringBuilder();
-        String[] split = text.trim().split("\\s");
+        String[] split = text.trim().split("\\s+");
         for (String s : split) {
             String res = "";
             if (s.length() == 1) {

--- a/src/test/java/kyu6/EncryptThisTest.java
+++ b/src/test/java/kyu6/EncryptThisTest.java
@@ -18,6 +18,17 @@ import static kyu6.EncryptThis.*;
 @Tag("smoke")
 public class EncryptThisTest {
     @Test
+    void encryptsWordsSeparatedByWhitespace() {
+        assertEquals("65 66", encryptThis("A  B"));
+        assertEquals("65 66", encryptThis(" A\tB "));
+    }
+
+    @Test
+    void returnsEmptyStringForBlankInput() {
+        assertEquals("", encryptThis(" \t\n"));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu6.EncryptThis.class);
     }


### PR DESCRIPTION
### Motivation
- The `encryptThis` helper could throw `StringIndexOutOfBoundsException` on whitespace-only input or when consecutive whitespace produced empty tokens, so make the function robust to such inputs. 
- Tokenization should treat runs of whitespace as a single separator to preserve expected behavior for inputs with mixed or repeated whitespace. 

### Description
- Return early for blank inputs by changing the guard to `if (text == null || text.isBlank()) return "";` in `src/main/java/kyu6/EncryptThis.java`. 
- Change tokenization to split on runs of whitespace by using `text.trim().split("\s+")` to avoid empty tokens. 
- Add regression tests in `src/test/java/kyu6/EncryptThisTest.java` that assert correct behavior for consecutive/mixed whitespace and that blank input returns an empty string. 

### Testing
- Ran the targeted test with `mvn -q -Dtest=EncryptThisTest test`, which passed. 
- Ran the full suite with `mvn -q test`, which passed. 
- Verified no diff check issues with `git diff --check` (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb6278ff883278b5ee29d598e7923)