### PR TITLE
Reject overflowing digit recompositions

### DIFF
--- a/src/main/java/kyu7/DescendingOrder.java
+++ b/src/main/java/kyu7/DescendingOrder.java
@@ -18,12 +18,12 @@ public class DescendingOrder {
             arrayList.add(i);
         }
         arrayList.sort(Comparator.reverseOrder());
-        int result = 0;
+        StringBuilder result = new StringBuilder();
         for (int i : arrayList
         ) {
-            result = result * 10 + i;
+            result.append(i);
         }
-        return result;
+        return Integer.parseInt(result.toString());
     }
 
 }

--- a/src/main/java/kyu7/MinimumLine.java
+++ b/src/main/java/kyu7/MinimumLine.java
@@ -2,6 +2,7 @@ package kyu7;
 
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 
 public class MinimumLine {
@@ -9,10 +10,12 @@ public class MinimumLine {
     // 7 https://www.codewars.com/kata/5ac6932b2f317b96980000ca/train/java
 
     public static int minValue(int[] values) {
-        return Arrays.stream(values)
+        String result = Arrays.stream(values)
                 .sorted()
                 .distinct()
-                .reduce(0, (result, digit) -> result * 10 + digit);
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining());
+        return Integer.parseInt(result);
     }
 
 }

--- a/src/test/java/kyu7/DescendingOrderTest.java
+++ b/src/test/java/kyu7/DescendingOrderTest.java
@@ -18,6 +18,11 @@ import static kyu7.DescendingOrder.*;
 @Tag("smoke")
 public class DescendingOrderTest {
     @Test
+    void rejectsReorderedValuesOutsideIntegerRange() {
+        assertThrows(NumberFormatException.class, () -> sortDesc(2_147_483_647));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu7.DescendingOrder.class);
     }

--- a/src/test/java/kyu7/MinimumLineTest.java
+++ b/src/test/java/kyu7/MinimumLineTest.java
@@ -18,6 +18,13 @@ import static kyu7.MinimumLine.*;
 @Tag("smoke")
 public class MinimumLineTest {
     @Test
+    void rejectsConcatenatedValuesOutsideIntegerRange() {
+        int[] values = {9, 8, 7, 6, 5, 4, 3, 2, 1, 99};
+
+        assertThrows(NumberFormatException.class, () -> minValue(values));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu7.MinimumLine.class);
     }


### PR DESCRIPTION
### Motivation

- Restore previous semantics where concatenated digit sequences reject out-of-range results instead of silently wrapping due to unchecked `int` arithmetic.

### Description

- Change `DescendingOrder.sortDesc` to build the reordered digits with a `StringBuilder` and return `Integer.parseInt(...)` so values outside `int` range throw `NumberFormatException`.
- Change `MinimumLine.minValue` to concatenate sorted distinct values via `mapToObj(String::valueOf)` and `Collectors.joining()` and return `Integer.parseInt(...)` to preserve concatenation semantics and reject overflow.
- Add regression tests `rejectsReorderedValuesOutsideIntegerRange` in `DescendingOrderTest` and `rejectsConcatenatedValuesOutsideIntegerRange` in `MinimumLineTest` that assert a `NumberFormatException` is thrown for the reported overflowing inputs.

### Testing

- Ran `mvn -q -Dtest=DescendingOrderTest,MinimumLineTest test` and the targeted tests passed.
- Ran full test suite with `mvn -q test` and it completed successfully in this environment.
- Ran `git diff --check` to validate no whitespace/diff issues and the working tree was clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627f2d4832785dbbe44deefcb46)