### PR TITLE
Fail smoke tests when any reflected invocation fails

### DIFF
--- a/src/test/java/quality/SmokeMethodTestHarness.java
+++ b/src/test/java/quality/SmokeMethodTestHarness.java
@@ -58,7 +58,7 @@ public final class SmokeMethodTestHarness {
         }
 
         String summary = String.format("%s attempted=%d failed=%d", clazz.getSimpleName(), attempted, failed);
-        Assertions.assertTrue(failed < attempted, () -> "Every executable smoke path failed: " + summary);
+        Assertions.assertEquals(0, failed, () -> "Executable smoke path failed: " + summary);
     }
 
     private static Object resolveTargetInstance(Method method, Class<?> clazz) throws Exception {

--- a/src/test/java/quality/SmokeMethodTestHarnessTest.java
+++ b/src/test/java/quality/SmokeMethodTestHarnessTest.java
@@ -1,6 +1,5 @@
 package quality;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ class SmokeMethodTestHarnessTest {
     }
 
     @Test
-    void acceptsAClassWhenAtLeastOneExecutablePathSucceeds() {
-        assertDoesNotThrow(() -> SmokeMethodTestHarness.verify(PartiallyWorks.class));
+    void rejectsAClassWhenAnyExecutablePathFails() {
+        assertThrows(AssertionError.class, () -> SmokeMethodTestHarness.verify(PartiallyWorks.class));
     }
 
     private static final class AlwaysFails {


### PR DESCRIPTION
### Motivation
- The smoke harness previously counted reflective invocation failures but only asserted that at least one invocation was attempted, allowing crashes to be masked by a single successful invocation. 
- The change aims to strengthen the smoke-test signal so that any crashing executable path causes the harness to fail, preserving the original intention of exposing regressions.

### Description
- Change the final check in `quality.SmokeMethodTestHarness.verify(...)` to `Assertions.assertEquals(0, failed, ...)` so the harness fails when any reflected invocation throws. 
- Update `quality.SmokeMethodTestHarnessTest` to assert that a class with any failing executable path triggers an `AssertionError`, renaming the test to reflect the stricter behaviour. 
- Remove the now-unused `assertDoesNotThrow` import and keep the existing summary diagnostics in the failure message.

### Testing
- Ran `mvn -Dtest=quality.SmokeMethodTestHarnessTest test` and the harness regression tests passed (2 tests, 0 failures). 
- Ran `mvn test` and the full test suite completed successfully (`Tests run: 597, Failures: 0, Errors: 0`). 
- Ran `mvn -DskipTests checkstyle:check` and there were no Checkstyle violations (build success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627b4b883279b9307ff9642cf8d)