### PR TITLE
Prevent overflow in sliding average updates

### DIFF
--- a/src/main/java/algorithms/sprint0/SlidingAverage.java
+++ b/src/main/java/algorithms/sprint0/SlidingAverage.java
@@ -28,7 +28,7 @@ public class SlidingAverage {
         }
         result.add(sum / (double) windowSize);
         for (int i = windowSize; i < minSize; i++) {
-            sum += arr.get(i) - arr.get(i - windowSize);
+            sum += (long) arr.get(i) - arr.get(i - windowSize);
             result.add(sum / (double) windowSize);
         }
         return result;

--- a/src/test/java/algorithms/sprint0/SlidingAverageTest.java
+++ b/src/test/java/algorithms/sprint0/SlidingAverageTest.java
@@ -49,6 +49,13 @@ class SlidingAverageTest {
         assertListDoubles(SlidingAverage.movingAverage(4, List.of(max, max, max, max), 2), max, max, max);
     }
 
+    @Test
+    void extremeValuesDoNotOverflowTheRollingUpdate() {
+        assertListDoubles(SlidingAverage.movingAverage(
+                2, List.of(Integer.MIN_VALUE, Integer.MAX_VALUE), 1),
+                Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
     private static void assertListDoubles(List<Double> actual, double... expected) {
         assertEquals(expected.length, actual.size(), "size");
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
### Motivation

- The rolling-window update used `arr.get(i) - arr.get(i - windowSize)` which performs 32-bit subtraction before adding to the `long` accumulator and can produce incorrect averages for edge-case `int` inputs.

### Description

- Widen the incoming value before subtraction by changing the update to `sum += (long) arr.get(i) - arr.get(i - windowSize);` in `SlidingAverage.movingAverage` to ensure 64-bit arithmetic for the delta.
- Add a regression unit test `extremeValuesDoNotOverflowTheRollingUpdate` that verifies a transition from `Integer.MIN_VALUE` to `Integer.MAX_VALUE` with `windowSize = 1` produces the correct values.
- Changes touch `src/main/java/algorithms/sprint0/SlidingAverage.java` and `src/test/java/algorithms/sprint0/SlidingAverageTest.java` and preserve existing behavior for non-extreme inputs.

### Testing

- Ran the focused unit suite with `mvn -B -Dtest=algorithms.sprint0.SlidingAverageTest test` and the `SlidingAverage` test class passed (8 tests, 0 failures).
- Ran the full verification gate with `mvn -B verify` which completed successfully (all tests passed and build checks including coverage, Checkstyle, PMD, and SpotBugs showed no blocking issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626eac48327b50d7c65d1d64f67)