### PR TITLE
Fix Unicode case expansion in AdjustCase

### DIFF
--- a/src/main/java/other/AdjustCase.java
+++ b/src/main/java/other/AdjustCase.java
@@ -13,7 +13,7 @@ public class AdjustCase {
     public String adjustCaseToLower(String string) {
         if (string == null || string.length() == 0) return string;
         if (string.length() == 1) return string.toUpperCase(Locale.ROOT);
-        var stringLover = string.toLowerCase(Locale.ROOT).substring(1);
+        var stringLover = string.substring(1).toLowerCase(Locale.ROOT);
         var firstChar = string.substring(0, 1).toUpperCase(Locale.ROOT);
         return firstChar + stringLover;
     }

--- a/src/test/java/other/AdjustCaseTest.java
+++ b/src/test/java/other/AdjustCaseTest.java
@@ -18,6 +18,13 @@ import static other.AdjustCase.*;
 @Tag("smoke")
 public class AdjustCaseTest {
     @Test
+    void adjustsSuffixWithoutRetainingExpandedLowercaseCharacters() {
+        other.AdjustCase adjustCase = new other.AdjustCase();
+
+        assertEquals("\u0130bc", adjustCase.adjustCaseToLower("\u0130BC"));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(other.AdjustCase.class);
     }


### PR DESCRIPTION
### Motivation
- Repair a Unicode correctness regression in `adjustCaseToLower` where lowercasing the whole string first could produce multi-code-point expansions (e.g. U+0130 → `i` + combining dot) and leave the combining mark in the suffix.

### Description
- Change the order of operations to separate the original first UTF-16 unit and then lowercase the remainder with `string.substring(1).toLowerCase(Locale.ROOT)` to avoid retaining extra code points produced by the first character's case mapping.
- Preserve the original behavior of uppercasing the first unit via `string.substring(0, 1).toUpperCase(Locale.ROOT)` and concatenating it with the lowercased suffix.
- Add a focused regression test `adjustsSuffixWithoutRetainingExpandedLowercaseCharacters` that asserts `other.AdjustCase.adjustCaseToLower("\u0130BC")` yields `"\u0130bc"`.

### Testing
- Ran `mvn -Dtest=AdjustCaseTest test` and the test suite containing the new regression test completed successfully (`Tests run: 2, Failures: 0`).
- Ran `git diff --check` and `git status` to ensure no whitespace or repository issues and a clean working tree.
- The change is limited and unit-tested to prevent reintroduction of the combining-character regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb62714648327b08bef712b3b3f90)