### PR TITLE
Fix sequence counting across separated zeros

### DIFF
--- a/src/main/java/interview/MaximumSequenceWithOneZero.java
+++ b/src/main/java/interview/MaximumSequenceWithOneZero.java
@@ -1,7 +1,6 @@
 package interview;
 
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,24 +15,20 @@ public class MaximumSequenceWithOneZero {
         if (b.size() == 1 && b.get(0) == 1) return 1;
         if (b.size() == 1 && b.get(0) == 0) return 0;
 
-        List<Integer> bytes = new ArrayList<>(b);
         int maxCount = 0;
-        int count = 0;
-        if (bytes.get(0) == 1) count++;
+        int previousCount = 0;
+        int currentCount = 0;
 
-        for (int i = 1; i < bytes.size(); i++) {
-            if (bytes.get(i) == 1 && bytes.get(i - 1) == 1) {
-                count++;
-            }
-            if (bytes.get(i) == 1 && bytes.get(i - 1) == 0) {
-                count++;
-            }
-            if (bytes.get(i) == 0 && bytes.get(i - 1) == 0) {
-                maxCount = Math.max(count, maxCount);
-                count = 0;
+        for (Integer value : b) {
+            if (value == 1) {
+                currentCount++;
+                maxCount = Math.max(maxCount, previousCount + currentCount);
+            } else {
+                previousCount = currentCount;
+                currentCount = 0;
             }
         }
-        return Math.max(count, maxCount);
+        return maxCount;
     }
 
 

--- a/src/test/java/interview/MaximumSequenceWithOneZeroTest.java
+++ b/src/test/java/interview/MaximumSequenceWithOneZeroTest.java
@@ -29,6 +29,11 @@ class MaximumSequenceWithOneZeroTest {
     }
 
     @Test
+    void shouldNotCountAcrossMultipleSeparatedZeros() {
+        assertEquals(2, maximumSequenceWithOneZero(List.of(1, 0, 1, 0, 1)));
+    }
+
+    @Test
     void shouldCountAllOnesWhenThereIsNoZeroSeparator() {
         assertEquals(5, maximumSequenceWithOneZero(List.of(1, 1, 1, 1, 1)));
     }


### PR DESCRIPTION
### Motivation
- The existing `maximumSequenceWithOneZero` implementation accumulated runs across multiple non-consecutive zeros and returned incorrect results for inputs like `[1, 0, 1, 0, 1]`.

### Description
- Replace the single accumulating counter with `previousCount` and `currentCount` and compute `maxCount` as `previousCount + currentCount` while iterating, so only a single zero-separated pair contributes to the sum.
- Remove the unnecessary `ArrayList` copy and add a regression test `shouldNotCountAcrossMultipleSeparatedZeros` in `MaximumSequenceWithOneZeroTest.java` that asserts `maximumSequenceWithOneZero(List.of(1, 0, 1, 0, 1)) == 2`.

### Testing
- Ran the focused unit test with `mvn -q -Dtest=interview.MaximumSequenceWithOneZeroTest test` and it passed.
- Ran the full test suite with `mvn -q test` and `mvn -q verify`, both completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626ecfc832785a9e48feae77fd2)