### PR TITLE
Prevent regex metacharacter crashes in CamelCase.toCamelCase

### DIFF
--- a/src/main/java/kyu6/CamelCase.java
+++ b/src/main/java/kyu6/CamelCase.java
@@ -29,9 +29,10 @@ public class CamelCase {
     }
 
     public static String toCamelCase(String str) {
+        if (str == null || str.isEmpty()) return "";
         return Arrays.stream(str.split(" "))
                 .filter(s -> s.length() > 0)
-                .map(s -> s.replaceFirst(s.substring(0, 1), s.substring(0, 1).toUpperCase(Locale.ROOT)))
+                .map(s -> s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1))
                 .collect(Collectors.joining()).trim();
     }
 

--- a/src/test/java/kyu6/CamelCaseTest.java
+++ b/src/test/java/kyu6/CamelCaseTest.java
@@ -21,4 +21,14 @@ public class CamelCaseTest {
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu6.CamelCase.class);
     }
+
+    @Test
+    void toCamelCaseShouldTreatRegexCharactersLiterally() {
+        assertEquals("[abc?def\\ghi$there", kyu6.CamelCase.toCamelCase("[abc ?def \\ghi $there"));
+    }
+
+    @Test
+    void toCamelCaseShouldHandleNullInput() {
+        assertEquals("", kyu6.CamelCase.toCamelCase(null));
+    }
 }


### PR DESCRIPTION
### Motivation
- `toCamelCase` used `String.replaceFirst` with the first character as a regex/replacement, which can throw `PatternSyntaxException` or `IllegalArgumentException` for inputs starting with metacharacters and crashes on `null` input.

### Description
- Add a null/empty guard in `kyu6.CamelCase.toCamelCase` to return an empty string for `null` or empty input.
- Replace the regex-based `replaceFirst` call with literal substring concatenation: `s.substring(0,1).toUpperCase(Locale.ROOT) + s.substring(1)` to avoid regex/replacement parsing of the first character.
- Add regression tests in `src/test/java/kyu6/CamelCaseTest.java` that assert correct behavior for inputs containing regex/replacement metacharacters and for `null` input.

### Testing
- Ran the CamelCase unit test: `mvn -q -Dtest=CamelCaseTest test` and it passed.
- Ran the full test suite: `mvn -q test` and it completed successfully for this change.
- Ran `git diff --check` to ensure no whitespace or patch issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626e68c8327a84110081ea50acc)