### PR TITLE
Restore DigitalRoot legacy API compatibility

### DIFF
--- a/src/main/java/kyu6/DigitalRoot.java
+++ b/src/main/java/kyu6/DigitalRoot.java
@@ -29,6 +29,18 @@ public class DigitalRoot {
     }
 
     /**
+     * Retains compatibility with the original Codewars API.
+     *
+     * @param n a non-negative integer
+     * @return the digital root of {@code n}
+     * @deprecated use {@link #digitalRoot(int)} instead
+     */
+    @Deprecated
+    public static int digital_root(int n) {
+        return digitalRoot(n);
+    }
+
+    /**
      * Digital root is the recursive sum of all the digits in a number.
      * Given n, take the sum of the digits of n. If that value has more than one
      * digit, continue reducing in this way until a single-digit number is produced.

--- a/src/test/java/kyu6/DigitalRootTest.java
+++ b/src/test/java/kyu6/DigitalRootTest.java
@@ -21,5 +21,6 @@ class DigitalRootTest {
     void shouldReduceNumberToSingleDigit(int value, int expected) {
         assertEquals(expected, DigitalRoot.digitalRoot(value));
         assertEquals(expected, DigitalRoot.digitalRootRecursiveStream(value));
+        assertEquals(expected, DigitalRoot.digital_root(value));
     }
 }


### PR DESCRIPTION
### Motivation

- Fix a source/binary compatibility regression introduced by renaming the public kata method from `digital_root(int)` to `digitalRoot(int)` so existing callers and Codewars harnesses continue to work.

### Description

- Add a deprecated compatibility wrapper `public static int digital_root(int n)` that delegates to the existing `digitalRoot(int)` implementation to preserve a single centralized behavior.
- Document the wrapper with Javadoc and mark it `@Deprecated` to encourage migration while retaining the old API.
- Extend the parameterized test `shouldReduceNumberToSingleDigit` to assert the legacy method returns the same results as `digitalRoot(int)` and `digitalRootRecursiveStream(int)` for the existing test cases.

### Testing

- Ran unit tests with `mvn -B -DskipTests=false test`, and all tests passed (597 tests, 0 failures/errors).
- Ran full verification with `mvn -B verify`, and the build succeeded with coverage thresholds met and no Checkstyle/PMD/SpotBugs issues.
- The changes are minimal and purely API-compatible, with behavior delegated to the unchanged implementation so existing functionality is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb6278b388327a550bd8f8f559c0d)