### PR TITLE
Handle zero input in expandedForm

### DIFF
--- a/src/main/java/kyu6/NumberInExpandedForm.java
+++ b/src/main/java/kyu6/NumberInExpandedForm.java
@@ -8,6 +8,9 @@ public class NumberInExpandedForm {
     //6 https://www.codewars.com/kata/5842df8ccbd22792a4000245/train/java
 
     public static String expandedForm(int num) {
+        if (num == 0) {
+            return "0";
+        }
         StringBuilder result = new StringBuilder();
         char[] chars = String.valueOf(num).toCharArray();
         for (int i = 0; i < chars.length; i++) {

--- a/src/test/java/kyu6/NumberInExpandedFormTest.java
+++ b/src/test/java/kyu6/NumberInExpandedFormTest.java
@@ -18,6 +18,11 @@ import static kyu6.NumberInExpandedForm.*;
 @Tag("smoke")
 public class NumberInExpandedFormTest {
     @Test
+    void zeroShouldRemainZero() {
+        assertEquals("0", expandedForm(0));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu6.NumberInExpandedForm.class);
     }


### PR DESCRIPTION
### Motivation
- Calling `expandedForm(0)` produced an empty buffer and then `substring(0, result.length() - 3)`, causing a `StringIndexOutOfBoundsException`, so the helper must handle zero robustly.

### Description
- Return `"0"` immediately when `expandedForm(int num)` is invoked with `num == 0`, preserving existing behavior for other inputs in `src/main/java/kyu6/NumberInExpandedForm.java`.
- Add a regression test `zeroShouldRemainZero` in `src/test/java/kyu6/NumberInExpandedFormTest.java` that asserts `expandedForm(0)` returns `"0"`.

### Testing
- Ran `mvn -Dtest=NumberInExpandedFormTest test` which executed the class-specific tests and they passed (2 tests, 0 failures).
- Ran full test suite with `mvn test` and all automated tests passed (598 tests, 0 failures or errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626e80c83279ed2211008964171)