### PR TITLE
Bound Tribonacci allocations for malformed lengths

### DIFF
--- a/src/main/java/kyu6/TribonacciSequence.java
+++ b/src/main/java/kyu6/TribonacciSequence.java
@@ -5,6 +5,7 @@ package kyu6;
 public class TribonacciSequence {
 
     private static final int SIGNATURE_SIZE = 3;
+    private static final int MAX_SEQUENCE_LENGTH = 1_000_000;
 
     //6 https://www.codewars.com/kata/556deca17c58da83c00002db
 
@@ -12,8 +13,10 @@ public class TribonacciSequence {
         if (s == null || s.length != SIGNATURE_SIZE) {
             throw new IllegalArgumentException("signature must contain exactly three values");
         }
-        if (n < 0) {
-            throw new IllegalArgumentException("sequence length must not be negative");
+        if (n < 0 || n > MAX_SEQUENCE_LENGTH) {
+            throw new IllegalArgumentException(
+                    "sequence length must be between 0 and " + MAX_SEQUENCE_LENGTH
+            );
         }
         double[] result = new double[n];
         int signatureLength = Math.min(SIGNATURE_SIZE, n);

--- a/src/test/java/kyu6/TribonacciSequenceTest.java
+++ b/src/test/java/kyu6/TribonacciSequenceTest.java
@@ -31,5 +31,9 @@ class TribonacciSequenceTest {
         assertThrows(IllegalArgumentException.class, () -> TribonacciSequence.tribonacci(null, 1));
         assertThrows(IllegalArgumentException.class, () -> TribonacciSequence.tribonacci(new double[]{1, 1}, 2));
         assertThrows(IllegalArgumentException.class, () -> TribonacciSequence.tribonacci(new double[]{1, 1, 1}, -1));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TribonacciSequence.tribonacci(new double[]{1, 1, 1}, Integer.MAX_VALUE)
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Harden the `TribonacciSequence.tribonacci` implementation to reject negative or excessively large `n` before allocating the result array, preventing crashes (NegativeArraySizeException/ArrayIndexOutOfBoundsException) and OutOfMemoryError for malformed inputs.

### Description
- Add `MAX_SEQUENCE_LENGTH = 1_000_000` and validate `n` (`0 <= n <= MAX_SEQUENCE_LENGTH`) in `src/main/java/kyu6/TribonacciSequence.java`, and add a regression case in `src/test/java/kyu6/TribonacciSequenceTest.java` that asserts `Integer.MAX_VALUE` is rejected without allocation.

### Testing
- Ran `mvn -q -Dtest=kyu6.TribonacciSequenceTest test` and `mvn -q test`, and ran `mvn -q -DskipTests checkstyle:check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626e15c83278a5d970598f9e3c5)