### PR TITLE
Handle null input in Maskify

### DIFF
--- a/src/main/java/kyu7/Maskify.java
+++ b/src/main/java/kyu7/Maskify.java
@@ -7,7 +7,7 @@ public class Maskify {
     //7 https://www.codewars.com/kata/5412509bd436bd33920011bc/train/java
 
     public static String maskify(String str) {
-        if (str.length() < 5) return str;
+        if (str == null || str.length() < 5) return str;
         return "#".repeat(str.length() - 4) + str.substring(str.length() - 4);
     }
 

--- a/src/test/java/kyu7/MaskifyTest.java
+++ b/src/test/java/kyu7/MaskifyTest.java
@@ -18,6 +18,11 @@ import static kyu7.Maskify.*;
 @Tag("smoke")
 public class MaskifyTest {
     @Test
+    void nullInputShouldRemainNull() {
+        assertNull(maskify(null));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu7.Maskify.class);
     }


### PR DESCRIPTION
### Motivation

- The `Maskify.maskify` method dereferenced its `str` parameter via `str.length()` and threw a `NullPointerException` when called with `null`, so a minimal robustness fix is needed.

### Description

- Add a null guard to `Maskify.maskify` so it returns `null` when called with a `null` argument and otherwise preserves the original masking behavior. 
- Add a regression test `nullInputShouldRemainNull` in `MaskifyTest` that asserts `maskify(null)` returns `null`.
- Changes are minimal and limited to `src/main/java/kyu7/Maskify.java` and `src/test/java/kyu7/MaskifyTest.java` to avoid altering existing functionality.

### Testing

- Ran `mvn -q -Dtest=MaskifyTest test` and the test suite targeting the modified test passed successfully. 
- Ran `mvn -q test` for the full test suite and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb6275e70832785439e38a54e6015)