### PR TITLE
Prevent SquareDigit overflow crash

### DIFF
--- a/src/main/java/kyu7/SquareDigit.java
+++ b/src/main/java/kyu7/SquareDigit.java
@@ -1,10 +1,9 @@
 package kyu7;
 
 
-import static common.SafeParse.parseInt;
-
-
 public class SquareDigit {
+
+    private static final String MAX_INT = Integer.toString(Integer.MAX_VALUE);
 
     //7 https://www.codewars.com/kata/546e2562b03326a88e000020/train/java
 
@@ -16,7 +15,12 @@ public class SquareDigit {
             n /= 10;
             stringBuilder.insert(0, i * i);
         }
-        return parseInt(stringBuilder.toString());
+        String result = stringBuilder.toString();
+        if (result.length() > MAX_INT.length()
+                || result.length() == MAX_INT.length() && result.compareTo(MAX_INT) > 0) {
+            return Integer.MAX_VALUE;
+        }
+        return Integer.parseInt(result);
     }
 
 }

--- a/src/test/java/kyu7/SquareDigitTest.java
+++ b/src/test/java/kyu7/SquareDigitTest.java
@@ -18,6 +18,16 @@ import static kyu7.SquareDigit.*;
 @Tag("smoke")
 public class SquareDigitTest {
     @Test
+    void squaresDigitsWhenResultFitsInAnInteger() {
+        assertEquals(811181, squareDigits(9119));
+    }
+
+    @Test
+    void capsResultsThatExceedIntegerRange() {
+        assertEquals(Integer.MAX_VALUE, squareDigits(99999));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu7.SquareDigit.class);
     }


### PR DESCRIPTION
### Motivation

- The `squareDigits` method concatenated squared digits and called `Integer.parseInt` without checking range, causing `NumberFormatException` for inputs like `99999` when the constructed decimal exceeds `Integer.MAX_VALUE`.
- The change aims to make the method robust for arbitrary `int` inputs while preserving existing behavior for values that fit in a Java `int`.

### Description

- Add a `MAX_INT` string constant and a pre-parse guard that compares the generated decimal string to `Integer.MAX_VALUE` by length and lexicographic order in `src/main/java/kyu7/SquareDigit.java`.
- If the generated result would exceed the `int` range the method now returns `Integer.MAX_VALUE` to avoid `NumberFormatException` while keeping representable results unchanged.
- Replace the previous direct parse with the guarded `Integer.parseInt` call on the validated string and remove reliance on unchecked parsing behavior.
- Add two unit tests in `src/test/java/kyu7/SquareDigitTest.java` that verify a normal case (`9119`) and the overflow/cap behavior for the reported `99999` input.

### Testing

- Ran `mvn -B -Dtest=SquareDigitTest test` and the `SquareDigitTest` suite passed (3 tests, 0 failures). 
- Ran the full verification `mvn -B verify` and the build succeeded, including JaCoCo coverage checks, Checkstyle, PMD, and SpotBugs. 
- The added unit tests exercise both the representable-path and the overflow-saturation-path and succeeded under the CI-quality gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626f9b48327a2af0e38d75a7e55)