### PR TITLE
Harden rail fence cipher decoding against resource exhaustion

### DIFF
--- a/src/main/java/kyu3/RailFenceCipher.java
+++ b/src/main/java/kyu3/RailFenceCipher.java
@@ -1,7 +1,6 @@
 package kyu3;
 
 
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -40,54 +39,34 @@ public class RailFenceCipher {
         // First computes the exact size of each rail, splits ciphertext into
         // contiguous rail segments, then reconstructs plaintext by replaying the
         // same rail traversal cycle.
+        if (n < 2) {
+            throw new IllegalArgumentException("Number of rails must be at least 2");
+        }
+        if (s.isEmpty() || n >= s.length()) {
+            return s;
+        }
+
         int[] size = new int[n];
         Counter counter = new Counter(n - 1);
         for (int i = 0; i < s.length(); i++) {
             int tik = counter.tik();
             size[tik]++;
         }
-        Map<Integer, StringBuilder> map = new TreeMap<>();
-        StringBuilder result = new StringBuilder();
+        int[] position = new int[n];
+        int start = 0;
         for (int i = 0; i < n; i++) {
-            StringBuilder stringBuilder = new StringBuilder();
-            if (i == 0) {
-                stringBuilder.append(s, 0, size[0]);
-            } else {
-                int start = sumArr(size, i);
-                int end = start + size[i];
-                stringBuilder.append(s, start, end);
-            }
-            map.put(i, stringBuilder);
+            position[i] = start;
+            start += size[i];
         }
 
-        Map<Integer, LinkedList<String>> map2 = new TreeMap<>();
-
-        for (Map.Entry<Integer, StringBuilder> e : map.entrySet()
-        ) {
-            LinkedList<String> strings = new LinkedList<>();
-            for (char c : e.getValue().toString().toCharArray()) {
-                strings.add(String.valueOf(c));
-            }
-            map2.put(e.getKey(), strings);
-        }
-
+        StringBuilder result = new StringBuilder(s.length());
         Counter counterRes = new Counter(n - 1);
         for (int i = 0; i < s.length(); i++) {
             int tik = counterRes.tik();
-            result.append(map2.get(tik).poll());
+            result.append(s.charAt(position[tik]++));
         }
 
         return result.toString();
-    }
-
-    private static int sumArr(int[] arr, int i) {
-        // Sum widths of all previous rails to determine the start offset
-        // of the current rail segment.
-        int result = 0;
-        for (int j = 0; j < i; j++) {
-            result += arr[j];
-        }
-        return result;
     }
 
     /**

--- a/src/test/java/kyu3/RailFenceCipherTest.java
+++ b/src/test/java/kyu3/RailFenceCipherTest.java
@@ -20,6 +20,12 @@ class RailFenceCipherTest {
         assertEquals("WEAREDISCOVEREDFLEEATONCE", RailFenceCipher.decode(encoded, 3));
     }
 
+    @Test
+    void shouldDecodeWithoutAllocatingForUnusedRails() {
+        assertEquals("", RailFenceCipher.decode("", Integer.MAX_VALUE));
+        assertEquals("abc", RailFenceCipher.decode("abc", Integer.MAX_VALUE));
+    }
+
     @ParameterizedTest
     @MethodSource("roundTripCases")
     void shouldRoundTripPlainTextForDifferentRails(String text, int rails) {


### PR DESCRIPTION
### Motivation
- The previous `decode` implementation performed allocations and O(n^2) work based on the caller-controlled rail count `n`, and created per-character `String`/`LinkedList` objects even for empty input, enabling CPU/memory exhaustion for large `n`.
- The change aims to prevent resource amplification while preserving the kata's decode semantics for valid inputs (rails >= 2) and typical test cases.

### Description
- Validate the rail count by throwing `IllegalArgumentException` if `n < 2`, and return immediately when `s.isEmpty()` or `n >= s.length()` to avoid unnecessary work and allocations.
- Replace the quadratic `sumArr` scans and `TreeMap`/`LinkedList` per-character conversions with an `int[] position` offset array and a single `StringBuilder` result to reconstruct characters directly from the input.
- Remove per-character `String` allocations and linked-list buffering so decoding runs in linear time relative to the input length plus rail bookkeeping.
- Add a regression test `shouldDecodeWithoutAllocatingForUnusedRails` asserting that extreme rail counts (e.g. `Integer.MAX_VALUE`) do not cause allocation or incorrect decoding for empty and short inputs.

### Testing
- Ran `mvn -Dtest=RailFenceCipherTest test` and the `RailFenceCipherTest` suite completed with all tests passing (5 tests, 0 failures).
- Ran the full test suite with `mvn -q test` and it completed successfully with no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627b72483279ce0da3f02ea97f8)