### PR TITLE
Validate Rail Fence cipher rail counts

### DIFF
--- a/src/main/java/kyu3/RailFenceCipher.java
+++ b/src/main/java/kyu3/RailFenceCipher.java
@@ -11,6 +11,7 @@ public class RailFenceCipher {
     //3 https://www.codewars.com/kata/58c5577d61aefcf3ff000081/train/java
 
     static String encode(String s, int n) {
+        validateRailCount(n);
         // Distributes characters across rails using a periodic index that walks
         // up and down between boundary rails, then concatenates each rail content.
         Map<Integer, StringBuilder> map = new TreeMap<>();
@@ -37,6 +38,7 @@ public class RailFenceCipher {
     }
 
     static String decode(String s, int n) {
+        validateRailCount(n);
         // First computes the exact size of each rail, splits ciphertext into
         // contiguous rail segments, then reconstructs plaintext by replaying the
         // same rail traversal cycle.
@@ -78,6 +80,12 @@ public class RailFenceCipher {
         }
 
         return result.toString();
+    }
+
+    private static void validateRailCount(int railCount) {
+        if (railCount < 2) {
+            throw new IllegalArgumentException("Rail count must be at least 2");
+        }
     }
 
     private static int sumArr(int[] arr, int i) {

--- a/src/test/java/kyu3/RailFenceCipherTest.java
+++ b/src/test/java/kyu3/RailFenceCipherTest.java
@@ -1,6 +1,7 @@
 package kyu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
@@ -28,11 +29,28 @@ class RailFenceCipherTest {
         assertEquals(text, RailFenceCipher.decode(encoded, rails));
     }
 
+    @ParameterizedTest
+    @MethodSource("invalidRailCounts")
+    void shouldRejectInvalidRailCounts(int rails) {
+        assertThrows(IllegalArgumentException.class,
+                () -> RailFenceCipher.encode("ABC", rails));
+        assertThrows(IllegalArgumentException.class,
+                () -> RailFenceCipher.decode("ABC", rails));
+    }
+
     private static Stream<Arguments> roundTripCases() {
         return Stream.of(
                 Arguments.of("", 2),
                 Arguments.of("Hello, World!", 4),
                 Arguments.of("Rail fence cipher keeps punctuation.", 5)
+        );
+    }
+
+    private static Stream<Arguments> invalidRailCounts() {
+        return Stream.of(
+                Arguments.of(-1),
+                Arguments.of(0),
+                Arguments.of(1)
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and undefined behavior when callers pass invalid rail counts to the Rail Fence cipher routines by failing fast with a clear error.
- Ensure both `encode` and `decode` respect the kata precondition that rails >= 2 and provide regression coverage for invalid inputs.

### Description
- Added a shared `validateRailCount(int)` helper that throws `IllegalArgumentException` when the rail count is less than 2 and invoked it from both `encode` and `decode` in `src/main/java/kyu3/RailFenceCipher.java`.
- Preserved existing traversal and reconstruction logic while avoiding prior arithmetic/null/indexing faults for invalid `n` values.
- Added a parameterized test `shouldRejectInvalidRailCounts` and `invalidRailCounts` test data to `src/test/java/kyu3/RailFenceCipherTest.java` and imported `assertThrows` to verify negative, zero, and single-rail inputs are rejected.

### Testing
- Ran the unit tests with `mvn -q -Dtest=RailFenceCipherTest test` and the new tests passed.
- Ran the full Maven verification with `mvn -q verify` and the build completed successfully including test and verification phases.
- Existing round-trip and example tests in `RailFenceCipherTest` continue to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627c3f8832783af603774b44704)