### PR TITLE
Handle overflow when reversing integers

### DIFF
--- a/src/main/java/other/ReverseInt.java
+++ b/src/main/java/other/ReverseInt.java
@@ -1,17 +1,13 @@
 package other;
 
 
-import static common.SafeParse.parseInt;
-
-
 public class ReverseInt {
 
     public static int reverse(int x) {
-        if (x >= 0) {
-            return parseInt(new StringBuilder(String.valueOf(x)).reverse().toString());
-        } else {
-            return parseInt(new StringBuilder(String.valueOf(x).substring(1)).reverse().toString()) * -1;
-        }
+        long reversed = Long.parseLong(new StringBuilder(String.valueOf(Math.abs((long) x))).reverse().toString());
+        reversed = x < 0 ? -reversed : reversed;
+
+        return reversed < Integer.MIN_VALUE || reversed > Integer.MAX_VALUE ? 0 : (int) reversed;
     }
 
 }

--- a/src/test/java/other/ReverseIntTest.java
+++ b/src/test/java/other/ReverseIntTest.java
@@ -16,7 +16,9 @@ class ReverseIntTest {
             "-123, -321",
             "120, 21",
             "-120, -21",
-            "1000000001, 1000000001"
+            "1000000001, 1000000001",
+            "1534236469, 0",
+            "-2147483648, 0"
     })
     void shouldReverseIntegerDigits(int input, int expected) {
         assertEquals(expected, ReverseInt.reverse(input));


### PR DESCRIPTION
### Motivation

- The existing `ReverseInt.reverse(int)` reversed the decimal string and used `Integer.parseInt`, which throws `NumberFormatException` when the reversed value exceeds 32-bit signed `int` bounds.  

### Description

- Replace string reversal + `Integer.parseInt` with parsing the reversed magnitude into a `long` using `Long.parseLong` after `Math.abs((long) x)`, then restore the sign and clamp out-of-range results.  
- The method now returns `0` when the reversed value is outside `Integer.MIN_VALUE..Integer.MAX_VALUE` while preserving previous behavior for in-range results.  
- Updated `src/main/java/other/ReverseInt.java` to implement the `long`-based reversal and bound check.  
- Extended `src/test/java/other/ReverseIntTest.java` with regression cases for a positive overflow (`1534236469`) and `Integer.MIN_VALUE` to ensure overflow returns `0`.

### Testing

- Ran the focused unit test with `mvn -B -Dtest=other.ReverseIntTest test`, and the test suite for that class passed (8 tests, 0 failures).  
- Ran the full verification build with `mvn -B verify`, and the project completed successfully (599 tests run, 0 failures) with Checkstyle, PMD, and SpotBugs analysis passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626fae0832787ebe8c040df42e2)