### PR TITLE
Validate Roman numeral parser input

### DIFF
--- a/src/main/java/kyu4/RomanNumerals.java
+++ b/src/main/java/kyu4/RomanNumerals.java
@@ -84,15 +84,22 @@ public class RomanNumerals {
     }
 
     public static int fromRoman(String romanNumeral) {
+        if (romanNumeral == null) {
+            throw new IllegalArgumentException("Roman numeral must not be null");
+        }
+
         // Traverse from right to left: add when symbol value is >= previous,
         // subtract otherwise. This naturally applies the subtractive rule.
         StringBuilder stringBuilderReverse = new StringBuilder(romanNumeral).reverse();
         char[] chars = stringBuilderReverse.toString().toCharArray();
-        int result = 0;
+        long result = 0;
         int previous = 0;
         for (char c : chars
         ) {
             Integer integer = MAP_FROM.get(c);
+            if (integer == null) {
+                throw new IllegalArgumentException("Unsupported Roman numeral character: " + c);
+            }
             if (integer >= previous) {
                 result += integer;
             } else {
@@ -101,7 +108,7 @@ public class RomanNumerals {
             previous = integer;
         }
 
-        return result;
+        return Math.toIntExact(result);
     }
 
 

--- a/src/test/java/kyu4/RomanNumeralsTest.java
+++ b/src/test/java/kyu4/RomanNumeralsTest.java
@@ -1,9 +1,11 @@
 package kyu4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,6 +32,19 @@ class RomanNumeralsTest {
         assertEquals(value, RomanNumerals.fromRoman(RomanNumerals.toRoman(value)));
     }
 
+    @ParameterizedTest
+    @MethodSource("invalidRomanNumerals")
+    void shouldRejectInvalidRomanNumerals(String romanNumeral) {
+        assertThrows(IllegalArgumentException.class, () -> RomanNumerals.fromRoman(romanNumeral));
+    }
+
+    @Test
+    void shouldRejectResultsOutsideIntegerRange() {
+        String romanNumeral = "M".repeat(2_147_484);
+
+        assertThrows(ArithmeticException.class, () -> RomanNumerals.fromRoman(romanNumeral));
+    }
+
     private static Stream<Arguments> romanCases() {
         return Stream.of(
                 Arguments.of(1, "I"),
@@ -44,5 +59,9 @@ class RomanNumeralsTest {
                 Arguments.of(2_008, "MMVIII"),
                 Arguments.of(3_999, "MMMCMXCIX")
         );
+    }
+
+    private static Stream<String> invalidRomanNumerals() {
+        return Stream.of((String) null, "A", "MCMX?");
     }
 }


### PR DESCRIPTION
### Motivation

- The `fromRoman` implementation unconditionally used `new StringBuilder(romanNumeral)` and unboxed `MAP_FROM.get(c)`, which caused `NullPointerException`s for null or unsupported input, and it accumulated into an `int` allowing silent overflow for very large inputs.

### Description

- Added a null check to `fromRoman` that throws `IllegalArgumentException` for `null` input.
- Added validation for unsupported characters by checking `MAP_FROM.get(c)` and throwing `IllegalArgumentException` when a character is not recognized.
- Changed the accumulator from `int` to `long` and returned `Math.toIntExact(result)` so values outside the `int` range trigger an `ArithmeticException` instead of wrapping.
- Added regression tests in `src/test/java/kyu4/RomanNumeralsTest.java` that assert proper exceptions for `null`, invalid characters, malformed input, and the integer-overflow boundary while keeping existing round-trip and conversion tests.

### Testing

- Ran `mvn -q -Dtest=kyu4.RomanNumeralsTest test` and the targeted test class passed.
- Ran `mvn test` and the full test suite completed successfully with 601 tests passing and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb627aa8c83279bf8e77c25a08a0a)