### PR TITLE
Prevent PigLatin crashes on empty whitespace tokens

### DIFF
--- a/src/main/java/kyu5/PigLatin.java
+++ b/src/main/java/kyu5/PigLatin.java
@@ -21,7 +21,9 @@ public class PigLatin {
         String[] words = str.split("\\s");
         for (String w : words
         ) {
-            if (!w.matches("\\W")) {
+            if (w.isEmpty()) {
+                continue;
+            } else if (!w.matches("\\W")) {
                 stringBuilder.append(w.substring(1)).append(w.charAt(0)).append(AY);
             } else {
                 stringBuilder.append(w).append(" ");

--- a/src/test/java/kyu5/PigLatinTest.java
+++ b/src/test/java/kyu5/PigLatinTest.java
@@ -21,4 +21,11 @@ public class PigLatinTest {
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu5.PigLatin.class);
     }
+
+    @Test
+    void handlesEmptyTokensWithoutThrowing() {
+        assertEquals("", pigIt(""));
+        assertEquals("eadinglay", pigIt(" leading"));
+        assertEquals("igPay atinlay", pigIt("Pig  latin"));
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix a crash in `kyu5.PigLatin.pigIt` where splitting on whitespace can produce empty tokens that reach `substring(1)`/`charAt(0)` and throw `StringIndexOutOfBoundsException` for empty input, leading spaces, or consecutive spaces.

### Description
- Add an explicit empty-token guard in `src/main/java/kyu5/PigLatin.java` with `if (w.isEmpty()) continue;` before performing the Pig Latin transformation.
- Preserve existing behavior for punctuation by keeping the `!w.matches("\\W")` branch and appending punctuation tokens unchanged.
- Add a regression test `handlesEmptyTokensWithoutThrowing` in `src/test/java/kyu5/PigLatinTest.java` that covers empty input, leading whitespace, and consecutive whitespace.
- Commit message: `Handle empty Pig Latin tokens safely`.

### Testing
- Ran `mvn -q -Dtest=PigLatinTest test` and the PigLatin test passed successfully.
- Ran `mvn -q test` and the full test suite passed successfully.
- Ran `mvn -q verify` and verification (including checks) completed successfully.
- Ran `git diff --check` and workspace status checks showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb626d43c8327b458acd9c2ebcd20)