### PR TITLE
Validate resistor input before color encoding

### DIFF
--- a/src/main/java/kyu5/ResistorColorCodes2.java
+++ b/src/main/java/kyu5/ResistorColorCodes2.java
@@ -9,9 +9,13 @@ public class ResistorColorCodes2 {
 
     public static String encodeResistorColors(String ohmsString) {
         if (ohmsString == null || !ohmsString.endsWith(" ohms")) return "";
-        int resistorOhms = encodeResistorOhms(ohmsString);
-        int[] resistorOhmsArr = encodeResistorOhmsToArr(resistorOhms);
-        return encodeResistorArrToColor(resistorOhmsArr);
+        try {
+            int resistorOhms = encodeResistorOhms(ohmsString);
+            int[] resistorOhmsArr = encodeResistorOhmsToArr(resistorOhms);
+            return encodeResistorArrToColor(resistorOhmsArr);
+        } catch (IllegalArgumentException e) {
+            return "";
+        }
     }
 
     private static int encodeResistorOhms(String ohmsString) {
@@ -22,6 +26,9 @@ public class ResistorColorCodes2 {
         else if (tempArray[0].endsWith("M"))
             tempValue = parseDouble(tempArray[0].trim().substring(0, tempArray[0].length() - 1)) * 1_000_000;
         else tempValue = parseDouble(tempArray[0].trim());
+        if (!Double.isFinite(tempValue) || tempValue < 10 || tempValue > 990_000_000) {
+            throw new IllegalArgumentException("Resistance must be between 10 and 990M ohms");
+        }
         return (int) Math.round(tempValue);
     }
 

--- a/src/test/java/kyu5/ResistorColorCodes2Test.java
+++ b/src/test/java/kyu5/ResistorColorCodes2Test.java
@@ -23,6 +23,9 @@ class ResistorColorCodes2Test {
         assertEquals("", ResistorColorCodes2.encodeResistorColors(null));
         assertEquals("", ResistorColorCodes2.encodeResistorColors("47"));
         assertEquals("", ResistorColorCodes2.encodeResistorColors("47 ohm"));
+        assertEquals("", ResistorColorCodes2.encodeResistorColors("abc ohms"));
+        assertEquals("", ResistorColorCodes2.encodeResistorColors("-1 ohms"));
+        assertEquals("", ResistorColorCodes2.encodeResistorColors("1e309 ohms"));
     }
 
     private static Stream<Arguments> resistorCases() {


### PR DESCRIPTION
### Motivation
- The public `ResistorColorCodes2.encodeResistorColors` accepted any string ending with `" ohms"` but did not validate the numeric token, allowing malformed, negative, or non-finite values to cause `NumberFormatException` or invalid enum indexes and crash the encoder. 
- Hardening was needed to keep behavior unchanged for valid kata inputs while rejecting untrusted or malformed values safely.

### Description
- Wrap the parsing/encoding flow in `encodeResistorColors` with a `try`/`catch` that returns an empty string for invalid inputs instead of propagating exceptions. 
- Add finite and bounds checks in `encodeResistorOhms` using `Double.isFinite(tempValue)` and a range check (`tempValue < 10 || tempValue > 990_000_000`) and throw `IllegalArgumentException` for values outside the supported 10 ohm to 990M ohm range. 
- Update `ResistorColorCodes2Test` to add regression assertions that `encodeResistorColors` returns `""` for malformed and out-of-range inputs such as `"abc ohms"`, `"-1 ohms"`, and `"1e309 ohms"`. 
- Files changed: `src/main/java/kyu5/ResistorColorCodes2.java`, `src/test/java/kyu5/ResistorColorCodes2Test.java`.

### Testing
- Ran `mvn -q -Dtest=kyu5.ResistorColorCodes2Test test` and the test class passed. 
- Ran full test suite with `mvn -q test` and the build/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb6273ff0832782759467fa57719f)