### PR TITLE
build(ci): update CodeQL action suite to 4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,13 +34,13 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Build for CodeQL
         run: mvn -B verify --file pom.xml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Combines Dependabot PRs #118 and #120 into one atomic CodeQL action-suite update. Individual PR CI fails only because init and analyze temporarily mix versions; this PR pins both steps to the same verified v4.37.6 digest. No checks are disabled or weakened.