### PR TITLE
Fix wrong isPrime results, an EOF loop in the sprint4 map reader and a mis-decoded morse colon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,21 +6,9 @@ updates:
       interval: weekly
     target-branch: main
     open-pull-requests-limit: 10
-  - package-ecosystem: maven
-    directory: "/"
-    schedule:
-      interval: weekly
-    target-branch: master
-    open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     target-branch: main
-    open-pull-requests-limit: 10
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-    target-branch: master
     open-pull-requests-limit: 10

--- a/src/main/java/algorithms/sprint4/Map.java
+++ b/src/main/java/algorithms/sprint4/Map.java
@@ -137,7 +137,7 @@ public class Map {
         private int len = 0;
 
         int read() throws IOException {
-            if (ptr == len) {
+            if (ptr >= len) {
                 len = in.read(buffer);
                 ptr = 0;
                 if (len == -1) {
@@ -189,6 +189,9 @@ public class Map {
         char nextCommand() throws IOException {
             int c = read();
             while (c <= ' ') {
+                if (c == -1) {
+                    throw new IOException("Unexpected end of input");
+                }
                 c = read();
             }
 

--- a/src/main/java/kyu4/MorseCodeDecoder.java
+++ b/src/main/java/kyu4/MorseCodeDecoder.java
@@ -56,8 +56,6 @@ public class MorseCodeDecoder {
         ALPHABET_TO_MORSE.put("0", "-----");
         ALPHABET_TO_MORSE.put(" ", "   ");
 
-        MORSE_TO_ALPHABET.put("a", "b");
-        MORSE_TO_ALPHABET.put("c", "d");
         MORSE_TO_ALPHABET.put("-.-.-.", ";");
         MORSE_TO_ALPHABET.put("-...-", "=");
         MORSE_TO_ALPHABET.put("---", "O");
@@ -84,7 +82,7 @@ public class MorseCodeDecoder {
         MORSE_TO_ALPHABET.put("-.", "N");
         MORSE_TO_ALPHABET.put("..---", "2");
         MORSE_TO_ALPHABET.put("-....", "6");
-        MORSE_TO_ALPHABET.put("---...", ";");
+        MORSE_TO_ALPHABET.put("---...", ":");
         MORSE_TO_ALPHABET.put(".-.-.", "+");
         MORSE_TO_ALPHABET.put(".--.-.", "@");
         MORSE_TO_ALPHABET.put("....-", "4");

--- a/src/main/java/kyu6/GiveMeDiamond.java
+++ b/src/main/java/kyu6/GiveMeDiamond.java
@@ -11,10 +11,10 @@ public class GiveMeDiamond {
         int count = n / 2 + 1;
         StringBuilder strings = new StringBuilder();
         for (int i = 1; i <= count; i++) {
-            strings.append(" ".repeat(count - i)).append("*".repeat(i * 2 - 1)).append(System.lineSeparator());
+            strings.append(" ".repeat(count - i)).append("*".repeat(i * 2 - 1)).append('\n');
         }
         for (int i = count - 1; i >= 1; i--) {
-            strings.append(" ".repeat(count - i)).append("*".repeat(i * 2 - 1)).append(System.lineSeparator());
+            strings.append(" ".repeat(count - i)).append("*".repeat(i * 2 - 1)).append('\n');
         }
         return strings.toString();
     }

--- a/src/main/java/kyu6/Prime.java
+++ b/src/main/java/kyu6/Prime.java
@@ -1,15 +1,24 @@
 package kyu6;
 
 
-import java.math.BigInteger;
-
 
 public class Prime {
 
     //6 https://www.codewars.com/kata/5262119038c0985a5b00029f/train/java
 
     public static boolean isPrime(int num) {
-        return num > 0 && BigInteger.valueOf(num).isProbablePrime((int) Math.log(num) + 1);
+        if (num < 2) {
+            return false;
+        }
+        if (num % 2 == 0) {
+            return num == 2;
+        }
+        for (int divisor = 3; (long) divisor * divisor <= num; divisor += 2) {
+            if (num % divisor == 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
 

--- a/src/test/java/algorithms/sprint4/MapTest.java
+++ b/src/test/java/algorithms/sprint4/MapTest.java
@@ -1,11 +1,17 @@
 package algorithms.sprint4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 @Tag("unit")
 class MapTest {
@@ -21,6 +27,23 @@ class MapTest {
         assertEquals(OptionalInt.of(20), table.delete(1));
         assertTrue(table.get(1).isEmpty());
         assertTrue(table.delete(1).isEmpty());
+    }
+
+    @Test
+    @Timeout(10)
+    void readerReportsEndOfInputInsteadOfReplayingTheBuffer() throws IOException {
+        InputStream original = System.in;
+        try {
+            System.setIn(new ByteArrayInputStream("g 7".getBytes(StandardCharsets.UTF_8)));
+            Map.Reader reader = new Map.Reader();
+
+            assertEquals('g', reader.nextCommand());
+            assertEquals(7, reader.nextInt());
+            assertThrows(IOException.class, reader::nextCommand);
+            assertThrows(IOException.class, reader::nextInt);
+        } finally {
+            System.setIn(original);
+        }
     }
 
     @Test

--- a/src/test/java/kyu4/MorseCodeDecoderTest.java
+++ b/src/test/java/kyu4/MorseCodeDecoderTest.java
@@ -51,6 +51,7 @@ class MorseCodeDecoderTest {
                 Arguments.of(".... . -.--", "HEY"),
                 Arguments.of("...---...", "SOS"),
                 Arguments.of("  .... . -.--   .--- ..- -.. .  ", "HEY JUDE"),
+                Arguments.of("---... -.-.-.", ":;"),
                 Arguments.of("", "")
         );
     }

--- a/src/test/java/kyu6/PrimeTest.java
+++ b/src/test/java/kyu6/PrimeTest.java
@@ -21,4 +21,16 @@ public class PrimeTest {
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu6.Prime.class);
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3, 5, 7, 11, 13, 101, 7919, 2147483647})
+    void shouldAcceptPrimes(int candidate) {
+        assertTrue(isPrime(candidate));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-7, -1, 0, 1, 4, 9, 15, 25, 49, 121, 7917, 2147483645})
+    void shouldRejectNonPrimes(int candidate) {
+        assertFalse(isPrime(candidate));
+    }
 }


### PR DESCRIPTION
## Summary

- **`kyu6.Prime.isPrime` returned true for composite numbers.** It called `BigInteger.isProbablePrime((int) Math.log(num) + 1)`, so the certainty was derived from the number itself: for `9` the certainty is `3`, i.e. Miller-Rabin was allowed to be wrong with probability up to 1/2^3. `isPrime(9)` reported `true` on roughly 2% of runs — a non-deterministic kata answer. Replaced with deterministic trial division (`num < 2` → false, even numbers handled, odd divisors up to `sqrt(num)`), which is also faster for `int`.
- **`algorithms.sprint4.Map.Reader` replayed its buffer after EOF.** `read()` refilled only when `ptr == len`; at EOF `len` becomes `-1` with `ptr == 0`, so the condition was false and the method kept returning stale bytes from the previous buffer (and eventually ran past its end). `ptr >= len` makes EOF sticky.
- **`nextCommand()` could spin forever.** Its whitespace skip loop had no EOF check, unlike `nextInt()`, so a truncated input (`n` larger than the number of commands actually supplied) left it looping on `-1` forever. It now throws `IOException("Unexpected end of input")`, which `main` already treats as rejected input.
- **Morse `---...` decoded to `;`.** `---...` is a colon; the semicolon `-.-.-.` was already mapped correctly one line above, so `:` could never be decoded. Also removed two leftover debug entries in the reverse table (`"a" → "b"`, `"c" → "d"`).
- **The diamond kata emitted CRLF on Windows.** `GiveMeDiamond.print` joined rows with `System.lineSeparator()`; the kata expects `\n`. `TowerBuilder.show()` was left alone — it is a display helper, not the kata answer.
- **`dependabot.yml` had two entries targeting `master`**, a branch that does not exist in this repository (default is `main`), so they could only ever error. Removed; the `main` entries for maven and github-actions stay.

## Not changed (needs a decision)

- `algorithms/sprint0/Utils.printList` swallows `IOException` per element. There is an explicit test (`UtilsTest.printListSwallowsWriterFailures`) asserting exactly that, so the behaviour is deliberate; changing it means changing the signature and the test.
- `algorithms/sprint6/DorogayaSet` uses `-1` as a "not found" sentinel, which collides with a legal answer. Fixing it changes the public method contract.
- Surefire only includes `**/*Test.java`, `**/*Tests.java`, `**/*TestCase.java` and `**/*IT.java`, so the tag-based suites in `src/test/java/quality/*Suite.java` never run in the build. Wiring them in would duplicate every test run — a decision about how the suites are meant to be used.

## Test plan

- `mvn -B -ntp verify` (JDK 21) — BUILD SUCCESS, `Tests run: 684, Failures: 0, Errors: 0, Skipped: 0`, including checkstyle, PMD, SpotBugs and the 70% JaCoCo gates.
- New assertions: `PrimeTest` now checks primes (2, 3, 5, 7, 11, 13, 101, 7919, 2147483647) and non-primes (-7, -1, 0, 1, 4, 9, 15, 25, 49, 121, 7917, 2147483645); the old code failed on 9 intermittently.
- New `MapTest.readerReportsEndOfInputInsteadOfReplayingTheBuffer` feeds `"g 7"` on `System.in` and asserts that the next `nextCommand()`/`nextInt()` throw instead of replaying the buffer; it carries `@Timeout(10)` so the old infinite loop would fail rather than hang the build.
- `MorseCodeDecoderTest` gained the case `"---... -.-.-."` → `":;"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
