### PR TITLE
Prevent integer overflow in AreSame square comparison

### DIFF
--- a/src/main/java/kyu6/AreSame.java
+++ b/src/main/java/kyu6/AreSame.java
@@ -12,10 +12,11 @@ public class AreSame {
     public static boolean comp(int[] a, int[] b) {
         return a != null && b != null && Arrays.equals(
                 Arrays.stream(a)
-                        .map(i -> i * i)
+                        .mapToLong(i -> (long) i * i)
                         .sorted()
                         .toArray(),
                 Arrays.stream(b)
+                        .mapToLong(i -> i)
                         .sorted()
                         .toArray());
     }

--- a/src/test/java/kyu6/AreSameTest.java
+++ b/src/test/java/kyu6/AreSameTest.java
@@ -18,6 +18,12 @@ import static kyu6.AreSame.*;
 @Tag("smoke")
 public class AreSameTest {
     @Test
+    void rejectsOverflowedSquares() {
+        assertFalse(comp(new int[]{46341}, new int[]{-2147479015}));
+        assertFalse(comp(new int[]{Integer.MIN_VALUE}, new int[]{0}));
+    }
+
+    @Test
     void smokeTestsShouldExecuteApi() {
         quality.SmokeMethodTestHarness.verify(kyu6.AreSame.class);
     }


### PR DESCRIPTION
### Motivation
- `AreSame.comp` squared `int` values using `i * i`, which silently overflows for |i| > 46340 and can make the comparison return incorrect true results.
- The change is intended to make the square comparison mathematically correct for all `int` inputs by avoiding wrapped 32-bit multiplication results.

### Description
- Use `mapToLong(i -> (long) i * i)` when squaring the first array so the multiplication is performed in 64-bit arithmetic before sorting and comparison.
- Widen the second stream to `long` via `mapToLong(i -> i)` so both sides are compared as `long[]` values and overflowed `int` squares cannot be accepted.
- Add a regression test `rejectsOverflowedSquares` in `AreSameTest` that asserts `comp(new int[]{46341}, new int[]{-2147479015})` and `comp(new int[]{Integer.MIN_VALUE}, new int[]{0})` return false.

### Testing
- Ran `mvn -Dtest=AreSameTest test` and the test suite executed the updated tests with `Tests run: 2, Failures: 0, Errors: 0` indicating success.
- Ran `git diff --check` locally to validate the workspace diff contains only the intended changes and reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d521162f4832793777e364783669b)