### PR TITLE
fix(kyu6): drop duplicates from WhichAreIn.inArray

### DIFF
--- a/src/main/java/kyu6/WhichAreIn.java
+++ b/src/main/java/kyu6/WhichAreIn.java
@@ -12,6 +12,7 @@ public class WhichAreIn {
         return Stream.of(array1)
                 .filter(word -> Stream.of(array2)
                         .anyMatch(bigWord -> bigWord.contains(word)))
+                .distinct()
                 .sorted().toList()
                 .toArray(String[]::new);
     }

--- a/src/test/java/kyu6/WhichAreInTest.java
+++ b/src/test/java/kyu6/WhichAreInTest.java
@@ -1,24 +1,39 @@
+package kyu6;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
 import org.junit.jupiter.api.Tag;
-import java.util.*;
-import java.util.stream.*;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import net.jqwik.api.Property;
-import net.jqwik.api.ForAll;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static kyu6.WhichAreIn.*;
+
 @Tag("smoke")
-public class WhichAreInTest {
+class WhichAreInTest {
+
     @Test
     void smokeTestsShouldExecuteApi() {
-        quality.SmokeMethodTestHarness.verify(kyu6.WhichAreIn.class);
+        quality.SmokeMethodTestHarness.verify(WhichAreIn.class);
+    }
+
+    @Test
+    void shouldReturnSortedSubstringsFromTheKataExample() {
+        String[] a1 = {"live", "arp", "strong"};
+        String[] a2 = {"lively", "alive", "harp", "sharp", "armstrong"};
+
+        assertArrayEquals(new String[]{"arp", "live", "strong"}, WhichAreIn.inArray(a1, a2));
+    }
+
+    @Test
+    void shouldReturnEmptyArrayWhenNothingIsContained() {
+        String[] a1 = {"tarp", "mice", "bull"};
+        String[] a2 = {"lively", "alive", "harp", "sharp", "armstrong"};
+
+        assertArrayEquals(new String[0], WhichAreIn.inArray(a1, a2));
+    }
+
+    @Test
+    void shouldNotRepeatWordsThatOccurTwiceInTheFirstArray() {
+        String[] a1 = {"arp", "live", "strong", "arp", "live"};
+        String[] a2 = {"lively", "alive", "harp", "sharp", "armstrong"};
+
+        assertArrayEquals(new String[]{"arp", "live", "strong"}, WhichAreIn.inArray(a1, a2));
     }
 }


### PR DESCRIPTION
Разбор брошенной ветки `claude/repository-audit-bugs-mku1k2` (6ca5fb9, 03.07.2026): из пяти описанных там дефектов четыре уже исправлены в main другими PR (`NumberOfTrailingZerosOfN`, `SortTheOdd`, `TheSupermarketQueue`, `CountingDuplicates`), пятый жив.

**Проблема.** Ката требует отсортированный результат без повторов, но `inArray` возвращал слово столько раз, сколько оно встречалось в первом массиве: для `["arp","live","strong","arp","live"]` — 5 элементов вместо 3. Дефект не ловился, потому что `WhichAreInTest` состоял из одного вызова `SmokeMethodTestHarness` без ассертов.

**Решение.** `.distinct()` в конвейере + реальные тесты: пример каты, пустой результат и кейс с повторами.

Проверено локально: без фикса новый тест падает (`expected: <3> but was: <5>`), с фиксом полный прогон `mvn clean test` — 688/688 зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)